### PR TITLE
hide top-bar and version-bar in print.css

### DIFF
--- a/src/assets/toolkit/styles/templates/_print.scss
+++ b/src/assets/toolkit/styles/templates/_print.scss
@@ -1,11 +1,13 @@
 @media print {
-  button, 
+  button,
   .button,
   button.button-link,
   .menu-icon,
+  .top-bar,
   .version-bar,
+  .translate-bar,
   .button-link,
-  .sub-nav, 
+  .sub-nav,
   footer img,
   .footer-section .inline-list,
   .button-stack--paginate {


### PR DESCRIPTION
@slowbot -- I just added `.top-bar` and `.version-bar` to hide from print, this allows the short form Review Summary to be printed nice and cleanly. 