### PR TITLE
Update print styling. See details:

### DIFF
--- a/src/assets/toolkit/styles/templates/_print.scss
+++ b/src/assets/toolkit/styles/templates/_print.scss
@@ -71,25 +71,21 @@
   }
 }
 
+.print-only.show-for-print { display: none !important; }
+
 .hide-for-print {
   @media print {
-    display: none;
-  }
-}
-
-.show-for-print {
-  @media print {
-    display: block;
+    display: none !important;
   }
 }
 
 @media print {
-  [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
-   display: block !important;
+  .show-for-print {
+    display: block;
   }
 
-  .ngTruncateToggleText {
-  display: none !important;
+  .ng-hide.show-for-print {
+    display: block !important;
   }
 }
 


### PR DESCRIPTION
1. .ng-hide.show-for-print displays markup for angular elements
2. .print-only.show-for-print overwrites foundation css so that it hides content only if both classes are there