### PR TITLE
Features/compile separate styles #143063589

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,9 @@ var config = {
 		},
 		styles: {
 			fabricator: 'src/assets/fabricator/styles/fabricator.scss',
-			toolkit: 'src/assets/toolkit/styles/toolkit.scss'
+			toolkit: 'src/assets/toolkit/styles/toolkit.scss',
+			toolkit_base: 'src/assets/toolkit/styles/toolkit-base.scss',
+			toolkit_lap: 'src/assets/toolkit/styles/toolkit-lap.scss'
 		},
 		images: 'src/assets/toolkit/images/**/*',
 		views: 'src/toolkit/views/*.html'
@@ -73,7 +75,31 @@ gulp.task('styles:toolkit', function () {
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });
 
-gulp.task('styles', ['styles:fabricator', 'styles:toolkit']);
+gulp.task('styles:toolkit_base', function () {
+	gulp.src(config.src.styles.toolkit_base)
+		.pipe(sourcemaps.init())
+		.pipe(sass().on('error', sass.logError))
+		.pipe(prefix('IE 9', 'last 4 versions'))
+		.pipe(gulpif(!config.dev, csso()))
+		.pipe(rename('toolkit-base.css'))
+		.pipe(sourcemaps.write())
+		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
+		.pipe(gulpif(config.dev, reload({stream:true})));
+});
+
+gulp.task('styles:toolkit_lap', function () {
+	gulp.src(config.src.styles.toolkit_lap)
+		.pipe(sourcemaps.init())
+		.pipe(sass().on('error', sass.logError))
+		.pipe(prefix('IE 9', 'last 4 versions'))
+		.pipe(gulpif(!config.dev, csso()))
+		.pipe(rename('toolkit-lap.css'))
+		.pipe(sourcemaps.write())
+		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
+		.pipe(gulpif(config.dev, reload({stream:true})));
+});
+
+gulp.task('styles', ['styles:fabricator', 'styles:toolkit', 'styles:toolkit_base', 'styles:toolkit_lap']);
 
 
 // scripts
@@ -210,6 +236,12 @@ gulp.task('serve', function () {
 
 	gulp.task('styles:toolkit:watch', ['styles:toolkit']);
 	gulp.watch('src/assets/toolkit/styles/**/*.scss', ['styles:toolkit:watch']);
+
+	gulp.task('styles:toolkit:watch', ['styles:toolkit_base']);
+	gulp.watch('src/assets/toolkit/styles/**/*.scss', ['styles:toolkit_base:watch']);
+
+	gulp.task('styles:toolkit:watch', ['styles:toolkit_lap']);
+	gulp.watch('src/assets/toolkit/styles/**/*.scss', ['styles:toolkit_lap:watch']);
 
 	gulp.task('scripts:watch', ['scripts'], reload);
 	gulp.watch('src/assets/{fabricator,toolkit}/scripts/**/*.js', ['scripts:watch']).on('change', webpackCache);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('styles:fabricator', function () {
 });
 
 gulp.task('styles:toolkit', function () {
-	gulp.src(config.src.styles.toolkit)
+	gulp.src([config.src.styles.toolkit, config.src.styles.toolkit_base, config.src.styles.toolkit_lap])
 		.pipe(sourcemaps.init())
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('IE 9', 'last 4 versions'))
@@ -75,31 +75,7 @@ gulp.task('styles:toolkit', function () {
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });
 
-gulp.task('styles:toolkit_base', function () {
-	gulp.src(config.src.styles.toolkit_base)
-		.pipe(sourcemaps.init())
-		.pipe(sass().on('error', sass.logError))
-		.pipe(prefix('IE 9', 'last 4 versions'))
-		.pipe(gulpif(!config.dev, csso()))
-		.pipe(rename('toolkit-base.css'))
-		.pipe(sourcemaps.write())
-		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
-		.pipe(gulpif(config.dev, reload({stream:true})));
-});
-
-gulp.task('styles:toolkit_lap', function () {
-	gulp.src(config.src.styles.toolkit_lap)
-		.pipe(sourcemaps.init())
-		.pipe(sass().on('error', sass.logError))
-		.pipe(prefix('IE 9', 'last 4 versions'))
-		.pipe(gulpif(!config.dev, csso()))
-		.pipe(rename('toolkit-lap.css'))
-		.pipe(sourcemaps.write())
-		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
-		.pipe(gulpif(config.dev, reload({stream:true})));
-});
-
-gulp.task('styles', ['styles:fabricator', 'styles:toolkit', 'styles:toolkit_base', 'styles:toolkit_lap']);
+gulp.task('styles', ['styles:fabricator', 'styles:toolkit']);
 
 
 // scripts
@@ -236,12 +212,6 @@ gulp.task('serve', function () {
 
 	gulp.task('styles:toolkit:watch', ['styles:toolkit']);
 	gulp.watch('src/assets/toolkit/styles/**/*.scss', ['styles:toolkit:watch']);
-
-	gulp.task('styles:toolkit:watch', ['styles:toolkit_base']);
-	gulp.watch('src/assets/toolkit/styles/**/*.scss', ['styles:toolkit_base:watch']);
-
-	gulp.task('styles:toolkit:watch', ['styles:toolkit_lap']);
-	gulp.watch('src/assets/toolkit/styles/**/*.scss', ['styles:toolkit_lap:watch']);
 
 	gulp.task('scripts:watch', ['scripts'], reload);
 	gulp.watch('src/assets/{fabricator,toolkit}/scripts/**/*.js', ['scripts:watch']).on('change', webpackCache);

--- a/src/assets/fabricator/styles/partials/_layout.scss
+++ b/src/assets/fabricator/styles/partials/_layout.scss
@@ -43,10 +43,15 @@ body {
 		}
 	}
 
-	h1 {
+	.f-item-leader {
 		font-family: $alt-font-family;
 		font-weight: 800;
 		text-transform: uppercase;
 		letter-spacing: 0.1rem;
+
+		&.t-preview {
+			text-transform: none;
+			font-weight: normal;
+		}
 	}
 }

--- a/src/assets/toolkit/styles/molecules/_message.scss
+++ b/src/assets/toolkit/styles/molecules/_message.scss
@@ -1,4 +1,4 @@
-// Text message with bouning box. 
+// Text message with bounding box. 
 
 .message {
   @include scut-padding(.5rem 1rem);

--- a/src/assets/toolkit/styles/toolkit-base.scss
+++ b/src/assets/toolkit/styles/toolkit-base.scss
@@ -1,0 +1,43 @@
+//
+// Toolkit styles
+//
+
+@import "settings";
+@import "vendors/normalize";
+
+// selectively include components
+@import
+   "../../vendor/foundation/scss/foundation/components/accordion",
+   "../../vendor/foundation/scss/foundation/components/alert-boxes",
+   "../../vendor/foundation/scss/foundation/components/block-grid",
+   "../../vendor/foundation/scss/foundation/components/breadcrumbs",
+   "../../vendor/foundation/scss/foundation/components/button-groups",
+   "../../vendor/foundation/scss/foundation/components/buttons",
+   "../../vendor/foundation/scss/foundation/components/clearing",
+   "../../vendor/foundation/scss/foundation/components/dropdown",
+   "../../vendor/foundation/scss/foundation/components/dropdown-buttons",
+   "../../vendor/foundation/scss/foundation/components/forms",
+   "../../vendor/foundation/scss/foundation/components/grid",
+   "../../vendor/foundation/scss/foundation/components/icon-bar",
+   "../../vendor/foundation/scss/foundation/components/inline-lists",
+   "../../vendor/foundation/scss/foundation/components/labels",
+   "../../vendor/foundation/scss/foundation/components/pagination",
+   "../../vendor/foundation/scss/foundation/components/panels",
+   "../../vendor/foundation/scss/foundation/components/progress-bars",
+   "../../vendor/foundation/scss/foundation/components/reveal",
+   "../../vendor/foundation/scss/foundation/components/sub-nav",
+   "../../vendor/foundation/scss/foundation/components/side-nav",
+   "../../vendor/foundation/scss/foundation/components/tables",
+   "../../vendor/foundation/scss/foundation/components/tabs",
+   "../../vendor/foundation/scss/foundation/components/tooltips",
+   "../../vendor/foundation/scss/foundation/components/top-bar",
+   "../../vendor/foundation/scss/foundation/components/visibility";
+
+@import "../../vendor/Scut/dist/scut";
+@import "vendors/angular-carousel";
+
+@import "utilities/all";
+
+@import "vendors-extensions/all";
+
+@import "atoms/all";

--- a/src/assets/toolkit/styles/toolkit-base.scss
+++ b/src/assets/toolkit/styles/toolkit-base.scss
@@ -41,3 +41,15 @@
 @import "vendors-extensions/all";
 
 @import "atoms/all";
+
+@import "molecules/alerts";
+@import "molecules/inputs";
+@import "molecules/loading";
+@import "molecules/message";
+@import "molecules/name-logo";
+@import "molecules/nav-mobile";
+@import "molecules/top-bar";
+
+@import "organisms/center-body";
+@import "organisms/header";
+@import "organisms/modal";

--- a/src/assets/toolkit/styles/toolkit-lap.scss
+++ b/src/assets/toolkit/styles/toolkit-lap.scss
@@ -47,6 +47,7 @@
 @import "molecules/content-card";
 @import "molecules/content-group";
 @import "molecules/header-badge";
+@import "molecules/info-item";
 @import "molecules/inputs";
 @import "molecules/labels";
 @import "molecules/lead-header";
@@ -60,6 +61,3 @@
 @import "organisms/center-body";
 @import "organisms/header";
 @import "organisms/modal";
-
-
-

--- a/src/assets/toolkit/styles/toolkit-lap.scss
+++ b/src/assets/toolkit/styles/toolkit-lap.scss
@@ -1,0 +1,65 @@
+//
+// Toolkit styles
+//
+
+@import "settings";
+@import "vendors/normalize";
+
+// selectively include components
+@import
+   "../../vendor/foundation/scss/foundation/components/accordion",
+   "../../vendor/foundation/scss/foundation/components/alert-boxes",
+   "../../vendor/foundation/scss/foundation/components/block-grid",
+   "../../vendor/foundation/scss/foundation/components/breadcrumbs",
+   "../../vendor/foundation/scss/foundation/components/button-groups",
+   "../../vendor/foundation/scss/foundation/components/buttons",
+   "../../vendor/foundation/scss/foundation/components/clearing",
+   "../../vendor/foundation/scss/foundation/components/dropdown",
+   "../../vendor/foundation/scss/foundation/components/dropdown-buttons",
+   "../../vendor/foundation/scss/foundation/components/forms",
+   "../../vendor/foundation/scss/foundation/components/grid",
+   "../../vendor/foundation/scss/foundation/components/icon-bar",
+   "../../vendor/foundation/scss/foundation/components/inline-lists",
+   "../../vendor/foundation/scss/foundation/components/labels",
+   "../../vendor/foundation/scss/foundation/components/pagination",
+   "../../vendor/foundation/scss/foundation/components/panels",
+   "../../vendor/foundation/scss/foundation/components/progress-bars",
+   "../../vendor/foundation/scss/foundation/components/reveal",
+   "../../vendor/foundation/scss/foundation/components/sub-nav",
+   "../../vendor/foundation/scss/foundation/components/side-nav",
+   "../../vendor/foundation/scss/foundation/components/tables",
+   "../../vendor/foundation/scss/foundation/components/tabs",
+   "../../vendor/foundation/scss/foundation/components/tooltips",
+   "../../vendor/foundation/scss/foundation/components/top-bar",
+   "../../vendor/foundation/scss/foundation/components/visibility";
+
+@import "../../vendor/Scut/dist/scut";
+@import "vendors/angular-carousel";
+
+@import "utilities/all";
+
+@import "vendors-extensions/all";
+
+@import "atoms/all";
+
+@import "molecules/alerts";
+@import "molecules/attachment";
+@import "molecules/content-card";
+@import "molecules/content-group";
+@import "molecules/header-badge";
+@import "molecules/inputs";
+@import "molecules/labels";
+@import "molecules/lead-header";
+@import "molecules/lined-nav";
+@import "molecules/loading";
+@import "molecules/message";
+@import "molecules/name-logo";
+@import "molecules/nav-mobile";
+@import "molecules/top-bar";
+
+@import "organisms/center-body";
+@import "organisms/header";
+@import "organisms/modal";
+
+
+

--- a/src/views/account.html
+++ b/src/views/account.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Account</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Account</h1>
 
 <ul>
 {{#each views.account.items}}

--- a/src/views/application.html
+++ b/src/views/application.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Application</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Application</h1>
 
 <ul>
 {{#each views.application.items}}

--- a/src/views/atoms.html
+++ b/src/views/atoms.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Atoms</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Atoms</h1>
 
 {{#each materials.atoms.items}}
 

--- a/src/views/browse.html
+++ b/src/views/browse.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Browse</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Browse</h1>
 
 <ul>
 {{#each views.browse.items}}

--- a/src/views/docs.html
+++ b/src/views/docs.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Docs</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Docs</h1>
 
 {{#each docs}}
 

--- a/src/views/eligibility.html
+++ b/src/views/eligibility.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Eligibility</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Eligibility</h1>
 
 <ul>
 {{#each views.eligibility.items}}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -62,21 +62,21 @@ fabricator: true
     <p class="f-item-intro t-epsilon">We recommend a font system that uses two open-source font families: Open Sans Pro and Droid Serif, both of which are designed for legibility and can beautifully adapt to a variety of visual styles.</p>
   </div>
   <div class="f-item-preview">
-    <h1>The quick brown fox jumps over the lazy dog</h1>
+    <h1 class="t-preview t-serif">The quick brown fox jumps over the lazy dog</h1>
     <p class="no-margin">.t-serif <br>
       <span class="t-micro">Droid Serif, Georgia, Times, serif</span>
     </p>
   </div>
 
   <div class="f-item-preview">
-    <h1 class="t-sans">The quick brown fox jumps over the lazy dog</h1>
+    <h1 class="t-preview t-sans">The quick brown fox jumps over the lazy dog</h1>
     <p>.t-sans <br>
       <span class="t-micro">Open Sans, Helvetica, Arial, Verdana, sans-serif</span>
     </p>
   </div>
 
   <div class="f-item-preview">
-    <h1 class="t-alt-sans t-caps t-black">The quick brown fox jumps over the lazy dog</h1>
+    <h1 class="t-preview t-alt-sans">The quick brown fox jumps over the lazy dog</h1>
     <p>.t-alt-sans <br>
       <span class="t-micro">Lato, Helvetica, Arial, Verdana, sans-serif</span>
     </p>

--- a/src/views/molecules.html
+++ b/src/views/molecules.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Molecules</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Molecules</h1>
 
 {{#each materials.molecules.items}}
 

--- a/src/views/organisms.html
+++ b/src/views/organisms.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Organisms</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Organisms</h1>
 
 <div ng-app="dahlia">
 {{#each materials.organisms.items}}

--- a/src/views/pages.html
+++ b/src/views/pages.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Pages</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Pages</h1>
 
 <ul>
 {{#each views.pages.items}}

--- a/src/views/property.html
+++ b/src/views/property.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Property</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Property</h1>
 
 <ul>
 {{#each views.property.items}}

--- a/src/views/samples.html
+++ b/src/views/samples.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Samples</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Samples</h1>
 
 <ul>
 {{#each views.samples.items}}

--- a/src/views/templates.html
+++ b/src/views/templates.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Templates</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Templates</h1>
 
 {{#each materials.templates.items}}
 

--- a/src/views/utilities.html
+++ b/src/views/utilities.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Utilities</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Utilities</h1>
 
 {{#each materials.utilities.items}}
 

--- a/src/views/utility-mixins.html
+++ b/src/views/utility-mixins.html
@@ -2,7 +2,7 @@
 fabricator: true
 ---
 
-<h1 data-f-toggle="labels">Utility Mixins</h1>
+<h1 data-f-toggle="labels" class="f-item-leader">Utility Mixins</h1>
 
 {{#each materials.utility-mixins.items}}
 


### PR DESCRIPTION
Creating three manifests for three different stylesheets to be out from the pattern library.

toolklt.scss is unchanged and reflects what we have today being consumed by the web app
toolkit-base.scss is only the base elements of the framework, including colors, forms, buttons etc
toolkit-lap.scss is base elements plus additional components that are used specifically in Leasing Agent Portal

Updated gulp file to run three watch and build tasks using the above naming convention. Curious to know your thoughts on naming of each of these tasks and filed and if we should try something different.


