### PR TITLE
Adding styles for lap modifiers

### DIFF
--- a/src/assets/toolkit/styles/molecules/_name-logo.scss
+++ b/src/assets/toolkit/styles/molecules/_name-logo.scss
@@ -10,6 +10,20 @@
     z-index: 103;
   }
 
+  // When there is no version bar present
+  &.no-offset {
+    @media #{$medium-up} {
+      margin-top: 0 !important;
+    }
+
+    a {
+      @media #{$medium-up} {
+        padding-bottom: rem-calc(4) !important;
+        padding-top: rem-calc(4) !important;
+      }
+    }
+  }
+
   a {
     // @include scut-image-replace;
     @include image-replace("../images/logo-portal.png");

--- a/src/assets/toolkit/styles/molecules/_top-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_top-bar.scss
@@ -34,7 +34,7 @@
   }
 
   // Applies responsive padding
-  &.inner--4x {
+  &.inner--3x {
     @include scut-padding(n 1rem);
 
     @media #{$medium-up} {
@@ -42,7 +42,7 @@
     }
 
     @media #{$large-up} {
-      @include scut-padding(n 4rem);
+      @include scut-padding(n 3rem);
     }
   }
 

--- a/src/assets/toolkit/styles/molecules/_top-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_top-bar.scss
@@ -5,15 +5,8 @@
 .top-bar {
   // Allows for full width navigation
   &.full-width {
-    @include scut-padding(n 1rem);
-
     @media #{$medium-up} {
-      @include scut-padding(n 2rem);
       height: auto;
-    }
-
-    @media #{$large-up} {
-      @include scut-padding(n 4rem);
     }
 
     .row {
@@ -30,37 +23,26 @@
     }
 
     .name-logo {
-      // Removes offset applied by version bar. Resolve with utility for version bar offset
       a {
         background-position: center center;
-
-        @media #{$medium-up} {
-          background-position: center 3rem;
-        }
       }
     }
 
-    // Allows for responsive left/right aligned nav-items
     .top-bar-section {
       width: auto;
-      float: right;
+    }
+  }
 
-      @media #{$large-up} {
-        float: right;
-      }
+  // Applies responsive padding
+  &.inner--4x {
+    @include scut-padding(n 1rem);
 
-      @media screen and (min-width: 75rem) {
-        float: none;
-      }
+    @media #{$medium-up} {
+      @include scut-padding(n 2rem);
     }
 
-    // Removes flex rules on default nav. Resolve with utility for flex nav menu
-    ul.nav-menu {
-      li {
-        @media #{$large-up} {
-          max-width: none;
-        }
-      }
+    @media #{$large-up} {
+      @include scut-padding(n 4rem);
     }
   }
 
@@ -86,6 +68,15 @@
       display: none;
     }
 
+    // Removes flex rules on default nav. Resolve with utility for flex nav menu
+    &.no-max-width-items {
+      > li {
+        @media #{$large-up} {
+          max-width: none;
+        }
+      }
+    }
+
     > li {
       background: transparent;
       width: auto;
@@ -98,8 +89,8 @@
       }
     }
 
-    li > a,
-    li:not(.has-form) a:not(.button) {
+    > li > a,
+    > li:not(.has-form) a:not(.button) {
       @include scut-padding(2.5rem 1rem 1rem 1rem);
       background: transparent;
       font-size: 0.75rem;
@@ -129,10 +120,6 @@
       border-bottom-width: 0;
       padding-top: 1rem;
       text-transform: capitalize;
-
-      &:hover {
-
-      }
     }
   }
 

--- a/src/assets/toolkit/styles/molecules/_top-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_top-bar.scss
@@ -3,11 +3,73 @@
 // Desktop navigation based on foundation top bar
 
 .top-bar {
+  // Allows for full width navigation
+  &.full-width {
+    @include scut-padding(n 1rem);
+
+    @media #{$medium-up} {
+      @include scut-padding(n 2rem);
+      height: auto;
+    }
+
+    @media #{$large-up} {
+      @include scut-padding(n 4rem);
+    }
+
+    .row {
+      max-width: none;
+    }
+
+    .title-area {
+      max-width: rem-calc(235);
+      height: 4.6875rem;
+    }
+
+    .name {
+      height: auto;
+    }
+
+    .name-logo {
+      // Removes offset applied by version bar. Resolve with utility for version bar offset
+      a {
+        background-position: center center;
+
+        @media #{$medium-up} {
+          background-position: center 3rem;
+        }
+      }
+    }
+
+    // Allows for responsive left/right aligned nav-items
+    .top-bar-section {
+      width: auto;
+      float: right;
+
+      @media #{$large-up} {
+        float: right;
+      }
+
+      @media screen and (min-width: 75rem) {
+        float: none;
+      }
+    }
+
+    // Removes flex rules on default nav. Resolve with utility for flex nav menu
+    ul.nav-menu {
+      li {
+        @media #{$large-up} {
+          max-width: none;
+        }
+      }
+    }
+  }
+
   .name-logo {
     display: flex;
   }
 }
 
+// Possible utility for flex menu items would make nav menu more reusbale
 .top-bar-section {
   width: 70%;
   left: auto !important;
@@ -24,7 +86,7 @@
       display: none;
     }
 
-    li {
+    > li {
       background: transparent;
       width: auto;
       height: 4.6875rem;
@@ -52,7 +114,8 @@
         font-size: 0.8125rem;
       }
 
-      &:hover {
+      &:hover,
+      &.active {
         border-bottom-color: $primary;
       }
     }

--- a/src/assets/toolkit/styles/organisms/_center-body.scss
+++ b/src/assets/toolkit/styles/organisms/_center-body.scss
@@ -24,7 +24,7 @@
     }
   }
 
-  &.inner {
+  &.inner--4x {
     @include scut-padding(n 1rem);
 
     @media #{$medium-up} {

--- a/src/assets/toolkit/styles/organisms/_center-body.scss
+++ b/src/assets/toolkit/styles/organisms/_center-body.scss
@@ -22,5 +22,17 @@
       padding-bottom: 4rem;
       padding-top: 4rem;
     }
-  } 
+  }
+
+  &.inner {
+    @include scut-padding(n 1rem);
+
+    @media #{$medium-up} {
+      @include scut-padding(n 2rem);
+    }
+
+    @media #{$large-up} {
+      @include scut-padding(n 4rem);
+    }
+  }
 }

--- a/src/assets/toolkit/styles/organisms/_center-body.scss
+++ b/src/assets/toolkit/styles/organisms/_center-body.scss
@@ -24,7 +24,7 @@
     }
   }
 
-  &.inner--4x {
+  &.inner--3x {
     @include scut-padding(n 1rem);
 
     @media #{$medium-up} {
@@ -32,7 +32,7 @@
     }
 
     @media #{$large-up} {
-      @include scut-padding(n 4rem);
+      @include scut-padding(n 3rem);
     }
   }
 }

--- a/src/assets/toolkit/styles/utilities/_grid.scss
+++ b/src/assets/toolkit/styles/utilities/_grid.scss
@@ -9,11 +9,6 @@
     max-width: none;
     width: auto;
   }
-
-  &.row-wide {
-    max-width: rem-calc(1180);
-    width: rem-calc(1180);
-  }
 }
 
 .fixed-width.columns {

--- a/src/assets/toolkit/styles/utilities/_grid.scss
+++ b/src/assets/toolkit/styles/utilities/_grid.scss
@@ -9,6 +9,11 @@
     max-width: none;
     width: auto;
   }
+
+  &.row-wide {
+    max-width: rem-calc(1180);
+    width: rem-calc(1180);
+  }
 }
 
 .fixed-width.columns {

--- a/src/assets/toolkit/styles/utilities/_spacing.scss
+++ b/src/assets/toolkit/styles/utilities/_spacing.scss
@@ -68,6 +68,36 @@ $units: (
         "left": true
       )
     ),
+    "three-times": (
+      "suffix": "--3x",
+      "media-query-max": $units__default-breakpoint, 
+      "unit--media-query-max": $default-unit, 
+      "media-query-min": $units__default-breakpoint,
+      "unit--media-query-min": $default-unit * 3,
+      "unit": $default-unit * 3,
+      "variations": (
+        "base": true,
+        "top": true,
+        "right": true,
+        "bottom": true,
+        "left": true
+      )
+    ),
+    "four-times": (
+      "suffix": "--4x",
+      "media-query-max": $units__default-breakpoint, 
+      "unit--media-query-max": $default-unit, 
+      "media-query-min": $units__default-breakpoint,
+      "unit--media-query-min": $default-unit * 4,
+      "unit": $default-unit * 4,
+      "variations": (
+        "base": true,
+        "top": true,
+        "right": true,
+        "bottom": true,
+        "left": true
+      )
+    ),
     "one-half-times": (
       "suffix": "--3halves",
       "media-query-max": $units__default-breakpoint, 


### PR DESCRIPTION
Created as part of implementing modifiers and variants for core layout components to LAP

- Adding full width component for topbar
- Limiting flex styles to parent li of navigation
- Adding an inner variant for inset app-container
- Adding active nav li state that was part of local styles in lap
- Adding additional spacing utility for 3x and 4x

There are a couple of modifications that I made that feel like they would benefit from a refactor of the core component.
- Should have added flex-nav as a modifier to the original component rather than baking into core
- Should add offset for version bar as a modifier
- Should add a layout rule for current default relationship between logo and nav widths

I recommend creating a story in an upcoming sprint to make these updates to PL and Dahlia

