### PR TITLE
Modal styles based on LAP

### DIFF
--- a/src/assets/toolkit/styles/atoms/_button-groups.scss
+++ b/src/assets/toolkit/styles/atoms/_button-groups.scss
@@ -81,3 +81,15 @@
     background-color: $dust;
   }
 }
+
+// Buttons stacked rather than inline
+.button-stack {
+  margin-bottom: 1rem;
+
+  button,
+  .button {
+    margin: 0 auto .25rem;
+    display: block;
+    width: 100%;
+  }
+}

--- a/src/assets/toolkit/styles/atoms/_button.scss
+++ b/src/assets/toolkit/styles/atoms/_button.scss
@@ -154,6 +154,16 @@ button,
     @extend .secondary;
   }
 
+  &.no-border {
+    background-color: transparent;
+    border-color: transparent;
+    color: $primary;
+
+    &:hover {
+      color: $deep;
+    }
+  }
+
   // Larger button styles
   &.large {
     @media #{$medium-up} {
@@ -371,17 +381,5 @@ input[type="submit"] {
 
   svg use {
     fill: $primary;
-  }
-}
-
-// Buttons stacked rather than inline
-.button-stack {
-  margin-bottom: 1rem;
-
-  button,
-  .button {
-    margin: 0 auto .25rem;
-    display: block;
-    width: 100%;
   }
 }

--- a/src/assets/toolkit/styles/molecules/_alerts.scss
+++ b/src/assets/toolkit/styles/molecules/_alerts.scss
@@ -68,11 +68,12 @@
     line-height: .9rem;
 
     &.text {
-      color: $primary;
+      color: inherit;
       font-size: rem-calc(12);
       opacity: 1;
       text-decoration: underline;
       text-transform: capitalize;
+      margin-top: -.5rem;
     }
   }
 }
@@ -84,7 +85,7 @@
 }
 
 .alert-body {
-  @include scut-padding(n n n 2rem);
+  @include scut-padding(n n n 1.325rem);
   margin-bottom: 0;
 }
 
@@ -96,7 +97,11 @@
   border: 2px solid $primary;
 
   &.alert {
-    border-color: $alert;
+    border-color: $alert-tint;
+
+    &.invert {
+      border-color: $alert;
+    }
   }
 
   p {

--- a/src/assets/toolkit/styles/organisms/_modal.scss
+++ b/src/assets/toolkit/styles/organisms/_modal.scss
@@ -49,6 +49,10 @@
 
 // Buttons stack with no column classes
 .modal-button-group {
+  &.row {
+    max-width: none;
+  }
+
   .modal-button_item {
     @media #{$medium-up} {
       float: right;

--- a/src/assets/toolkit/styles/organisms/_modal.scss
+++ b/src/assets/toolkit/styles/organisms/_modal.scss
@@ -36,6 +36,32 @@
     border-bottom-right-radius: $global-radius;
     border-bottom-left-radius: $global-radius;
   }
+
+  textarea {
+    height: 6.25rem;
+  }
+}
+
+.modal-footer {
+  border-bottom-right-radius: $global-radius;
+  border-bottom-left-radius: $global-radius;
+}
+
+// Buttons stack with no column classes
+.modal-button-group {
+  .modal-button_item {
+    @media #{$medium-up} {
+      float: right;
+      margin-left: 1rem;
+    }
+  }
+
+  button,
+  .button {
+    margin: 0 auto .25rem;
+    display: block;
+    width: 100%;
+  }
 }
 
 

--- a/src/materials/02-molecules/forms/alert-notice.html
+++ b/src/materials/02-molecules/forms/alert-notice.html
@@ -1,4 +1,4 @@
-<div class="alert-notice alert">
+<div class="alert-notice {{default status 'alert'}}">
   <p class="t-tiny c-alert margin-bottom">
     {{default alert-text "Your household income is too low."}}
   </p>

--- a/src/materials/02-molecules/forms/button-stack.html
+++ b/src/materials/02-molecules/forms/button-stack.html
@@ -1,8 +1,8 @@
-<div class="button-stack text-center row padding-top">
-  <div class="small-12 medium-6 columns">
+<div class="button-stack text-center row {{default classes 'padding-top'}}">
+  <div class="{{default l-columns 'small-12 medium-6 columns'}}">
     <button class="button {{default l-classes ''}}">{{default left 'Cancel'}}</button>
   </div>
-  <div class="small-12 medium-6 columns">
+  <div class="{{default r-columns 'small-12 medium-6 columns'}}">
     <button class="button {{default r-classes ''}}">{{default right 'Next'}}</button>
   </div>
 </div>

--- a/src/materials/02-molecules/forms/icon-input.html
+++ b/src/materials/02-molecules/forms/icon-input.html
@@ -5,7 +5,7 @@
         <input id="lottery_search_number" type="text" placeholder="Enter Your Lottery Number" class="icon-input-field squared no-margin">
       </div>
       <label class="small-2 columns">
-        <input type="submit">
+        <input type="submit" style="display: none;">
         <a href="#" class="icon-input-button button primary postfix squared no-margin"><span class="sr-only">Search</span> {{> icons.base icon="right" fill="white"}}</a>
 
         <!-- <a href="#" class="icon-input-button button postfix"><span class="sr-only">Clear</span> {{> icons.base icon="close" fill="white"}}</a> -->

--- a/src/materials/03-organisms/modal--message.html
+++ b/src/materials/03-organisms/modal--message.html
@@ -19,7 +19,7 @@
   </footer>
 
   <!-- <a class="close-reveal-modal" aria-label="Close"> -->
-  <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
+  <a class="close-reveal-modal" aria-label="Close">
     {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>

--- a/src/materials/03-organisms/modal--message.html
+++ b/src/materials/03-organisms/modal--message.html
@@ -2,13 +2,24 @@
   <header class="modal-inner">
     <h1 class="modal-title t-gamma no-margin">Confirmation needed</h1>
   </header>
-  {{> forms.alert-box status="primary" text="Email sent. Please check you inbox" classes="no-margin no-icon padding-left--3halves" close-style="text" close-text="close"}}
+  {{> forms.alert-box status="primary" text="Email sent. Please check you inbox" classes="no-margin no-icon padding-left--3halves" close-style="text" close-text="Close"}}
   <section class="modal-inner">
-    <p class="c-steel">An email has been sent to you@domain.com Please click on the link in that message to confirm your email address.</p>
-    {{> forms.button-stack left="OK" l-classes="primary right-on-medium" right="Resend the Email" r-classes="button-link button-lined small-text-center left-on-medium"}}
+    <p class="c-charcoal">An email has been sent to you@domain.com Please click on the link in that message to confirm your email address.</p>
   </section>
+
+  <footer class="modal-footer">
+    <div class="modal-button-group row">
+      <div class="modal-button_item">
+        <button class="button {{default l-classes 'primary'}}">{{default left 'Confirm'}}</button>
+      </div>
+      <div class="modal-button_item">
+        <button class="button {{default r-classes 'button-link button-lined small-text-center'}}">{{default right 'Resend the Email'}}</button>
+      </div>
+    </div>
+  </footer>
+
   <!-- <a class="close-reveal-modal" aria-label="Close"> -->
   <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
-    {{> icons.base icon="close" size="small" fill="primary"}}
+    {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>

--- a/src/materials/03-organisms/modal--small.html
+++ b/src/materials/03-organisms/modal--small.html
@@ -53,7 +53,7 @@
     </div>
   </section>
 
-  <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
+  <a class="close-reveal-modal" aria-label="Close">
     {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>

--- a/src/materials/03-organisms/modal-alert-invert.html
+++ b/src/materials/03-organisms/modal-alert-invert.html
@@ -26,7 +26,7 @@
   </footer>
 
   <!-- <a class="close-reveal-modal" aria-label="Close"> -->
-  <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
+  <a class="close-reveal-modal" aria-label="Close">
     {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>

--- a/src/materials/03-organisms/modal-alert-invert.html
+++ b/src/materials/03-organisms/modal-alert-invert.html
@@ -2,6 +2,8 @@
   <header class="modal-inner">
     <h1 class="modal-title t-gamma no-margin">Header</h1>
   </header>
+  {{> forms.alert-box status="alert invert" text="Email sent. Please check you inbox" classes="no-margin  padding-left--3halves" icon="warning" close-style="text" close-text="Close"}}
+  {{> forms.alert-notice status="alert invert"}}
 
   <section class="modal-inner">
     <p class="c-steel">Loreum ipsum</p>
@@ -15,7 +17,7 @@
   <footer class="modal-footer bg-dust">
     <div class="modal-button-group row">
       <div class="modal-button_item">
-        <button class="button {{default l-classes 'primary'}}">{{default left 'Submit'}}</button>
+        <button class="button {{default l-classes 'alert-fill'}}">{{default left 'Remove'}}</button>
       </div>
       <div class="modal-button_item">
         <button class="button {{default r-classes 'no-border'}}">{{default right 'Cancel'}}</button>

--- a/src/materials/03-organisms/modal-alert.html
+++ b/src/materials/03-organisms/modal-alert.html
@@ -26,7 +26,7 @@
   </footer>
 
   <!-- <a class="close-reveal-modal" aria-label="Close"> -->
-  <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
+  <a class="close-reveal-modal" aria-label="Close">
     {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>

--- a/src/materials/03-organisms/modal-alert.html
+++ b/src/materials/03-organisms/modal-alert.html
@@ -2,6 +2,8 @@
   <header class="modal-inner">
     <h1 class="modal-title t-gamma no-margin">Header</h1>
   </header>
+  {{> forms.alert-box status="alert" text="Email sent. Please check you inbox" classes="no-margin  padding-left--3halves" icon="warning" close-style="text" close-text="Close"}}
+  {{> forms.alert-notice status="alert"}}
 
   <section class="modal-inner">
     <p class="c-steel">Loreum ipsum</p>
@@ -15,7 +17,7 @@
   <footer class="modal-footer bg-dust">
     <div class="modal-button-group row">
       <div class="modal-button_item">
-        <button class="button {{default l-classes 'primary'}}">{{default left 'Submit'}}</button>
+        <button class="button {{default l-classes 'alert-fill'}}">{{default left 'Remove'}}</button>
       </div>
       <div class="modal-button_item">
         <button class="button {{default r-classes 'no-border'}}">{{default right 'Cancel'}}</button>

--- a/src/materials/03-organisms/modal.html
+++ b/src/materials/03-organisms/modal.html
@@ -23,8 +23,7 @@
     </div>
   </footer>
 
-  <!-- <a class="close-reveal-modal" aria-label="Close"> -->
-  <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
+  <a class="close-reveal-modal" aria-label="Close">
     {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>

--- a/src/materials/03-organisms/modal.html
+++ b/src/materials/03-organisms/modal.html
@@ -1,11 +1,29 @@
 <div aria-labelledby="modalTitle" aria-hidden="true" role="dialog">
-
   <header class="modal-inner">
     <h1 class="modal-title t-gamma no-margin">Header</h1>
   </header>
+  {{> forms.alert-box status="alert" text="Email sent. Please check you inbox" classes="no-margin  padding-left--3halves" icon="warning" close-style="text" close-text="Close"}}
+  {{> forms.alert-notice }}
+
   <section class="modal-inner">
     <p class="c-steel">Loreum ipsum</p>
+
+    <div class="form-group">
+      <label>Comment Required</label>
+    {{> forms.textarea }}
+    </div>
   </section>
+
+  <footer class="modal-footer bg-dust">
+    <div class="modal-button-group row">
+      <div class="modal-button_item">
+        <button class="button {{default l-classes 'primary'}}">{{default left 'Submit'}}</button>
+      </div>
+      <div class="modal-button_item">
+        <button class="button {{default r-classes 'no-border'}}">{{default right 'Cancel'}}</button>
+      </div>
+    </div>
+  </footer>
 
   <!-- <a class="close-reveal-modal" aria-label="Close"> -->
   <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">

--- a/src/views/pages/07-modal/modal.html
+++ b/src/views/pages/07-modal/modal.html
@@ -8,7 +8,7 @@
   </section>
 
   <!-- <a class="close-reveal-modal" aria-label="Close"> -->
-  <a class="close-reveal-modal" aria-label="Close"  ng-click="closeModal()">
+  <a class="close-reveal-modal" aria-label="Close">
     {{> icons.base icon="close" size="medium" fill="primary"}}
   </a>
 </div>


### PR DESCRIPTION
- Adding .modal-footer element and .modal-button-group elements
- Moving .button-stack variant from .button to .button-group
- Adding .no-border button variant
- Adjusted spacing for .alert-box and .alert-notice
- Adding .alert and .alert-invert variants to .alert-notice

Requires changes to DAHLIA
- Change all alert-notice instances in DAHLIA that use ..alert to use .alert.invert
- Update all modal actions to use .modal-footer element and .modal-button-group elements