### PR TITLE
Updating top bar navigation to use flex box as an option

### DIFF
--- a/src/assets/toolkit/styles/molecules/_name-logo.scss
+++ b/src/assets/toolkit/styles/molecules/_name-logo.scss
@@ -1,10 +1,10 @@
 // Logo
 .name-logo {
   background-color: #fff;
-  box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.25);
   width: 100%;
   
   @media #{$medium-up} {
+    box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.25);
     position: relative;
     z-index: 103;
   }

--- a/src/assets/toolkit/styles/molecules/_name-logo.scss
+++ b/src/assets/toolkit/styles/molecules/_name-logo.scss
@@ -5,27 +5,18 @@
   width: 100%;
   
   @media #{$medium-up} {
-    margin-top: -(rem-calc(36)) !important;
     position: relative;
     z-index: 103;
   }
 
-  // When there is no version bar present
-  &.no-offset {
+  // When there is version bar present
+  &.offset-up {
     @media #{$medium-up} {
-      margin-top: 0 !important;
-    }
-
-    a {
-      @media #{$medium-up} {
-        padding-bottom: rem-calc(4) !important;
-        padding-top: rem-calc(4) !important;
-      }
+      margin-top: -(rem-calc(36)) !important;
     }
   }
 
   a {
-    // @include scut-image-replace;
     @include image-replace("../images/logo-portal.png");
     background-position: center left;
     background-size: auto 100%;

--- a/src/assets/toolkit/styles/molecules/_name-logo.scss
+++ b/src/assets/toolkit/styles/molecules/_name-logo.scss
@@ -9,10 +9,20 @@
     z-index: 103;
   }
 
-  // When there is version bar present
-  &.offset-up {
+  // Offset when there's version bar present
+  &.is-offset-up {
     @media #{$medium-up} {
       margin-top: -(rem-calc(36)) !important;
+    }
+  }
+
+  // Logo height modifier
+  &.is-tall {
+    a {
+      @media #{$medium-up} {
+        padding-bottom: rem-calc(20) !important;
+        padding-top: rem-calc(20) !important;
+      }
     }
   }
 
@@ -24,11 +34,11 @@
     padding-top: rem-calc(0) !important;
     width: 100% !important;
 
-    @media #{$medium-up} {
+     @media #{$medium-up} {
       background-position: center center;
       background-size: 100% auto;
-      padding-bottom: rem-calc(20) !important;
-      padding-top: rem-calc(20) !important;
+      padding-bottom: rem-calc(4) !important;
+      padding-top: rem-calc(4) !important;
     }
   }
 }

--- a/src/assets/toolkit/styles/molecules/_top-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_top-bar.scss
@@ -3,8 +3,11 @@
 // Desktop navigation based on foundation top bar
 
 .top-bar {
+
   // Allows for full width navigation
   &.full-width {
+    overflow: visible;
+    
     @media #{$medium-up} {
       height: auto;
     }
@@ -30,6 +33,10 @@
 
     .top-bar-section {
       width: auto;
+
+      @media screen and (min-width: 75rem) {
+        float: none;
+      }
     }
   }
 
@@ -51,45 +58,48 @@
   }
 }
 
-// Possible utility for flex menu items would make nav menu more reusbale
 .top-bar-section {
   width: 70%;
   left: auto !important;
   height: 4.6875rem;
   float: right;
 
-  ul.nav-menu {
-    @media #{$medium-up} {
-      width: auto;
-      display: flex;
-    }
+  &.flex-items {
+    ul.nav-menu {
+      @media #{$medium-up} {
+        display: flex;
+      }
 
+      > li {
+        display: flex;
+
+        @media #{$large-up} {
+          max-width: 180px;
+          width: auto;
+        }
+      }
+
+      > li > a,
+      > li:not(.has-form) a:not(.button) {
+        display: flex;
+        align-self: flex-end;
+      }
+    }
+  }
+
+  ul.nav-menu {
     @media #{$small-only} {
       display: none;
     }
 
-    // Removes flex rules on default nav. Resolve with utility for flex nav menu
-    &.no-max-width-items {
-      > li {
-        @media #{$large-up} {
-          max-width: none;
-        }
-      }
+    @media #{$medium-up} {
+      width: auto;
     }
 
     > li {
       background: transparent;
       width: auto;
-    }
-
-    > li {
       height: 4.6875rem;
-      display: flex;
-
-      @media #{$large-up} {
-        max-width: 180px;
-        width: auto;
-      }
     }
 
     > li > a,
@@ -100,8 +110,6 @@
       line-height: 1rem;
       text-transform: uppercase;
       border-bottom: 3px solid transparent;
-      display: flex;
-      align-self: flex-end;
 
       @media #{$large-up} {
         @include scut-padding(n 1.5rem n 1.5rem);

--- a/src/assets/toolkit/styles/molecules/_top-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_top-bar.scss
@@ -6,7 +6,7 @@
 
   // Allows for full width navigation
   &.full-width {
-    overflow: visible;
+    // overflow: visible;
 
     @media #{$medium-up} {
       height: auto;

--- a/src/assets/toolkit/styles/molecules/_top-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_top-bar.scss
@@ -7,7 +7,7 @@
   // Allows for full width navigation
   &.full-width {
     overflow: visible;
-    
+
     @media #{$medium-up} {
       height: auto;
     }
@@ -64,7 +64,7 @@
   height: 4.6875rem;
   float: right;
 
-  &.flex-items {
+  &.has-flex-items {
     ul.nav-menu {
       @media #{$medium-up} {
         display: flex;

--- a/src/assets/toolkit/styles/molecules/_translate-bar.scss
+++ b/src/assets/toolkit/styles/molecules/_translate-bar.scss
@@ -2,30 +2,33 @@
   @include scut-padding(.625rem n);
   min-height: 2.1875rem;
 
-  .translate-bar_notice {
+  .translate-bar_notice-column {
     @media #{$xlarge-up} {
       padding-left: 0 !important;
     }
-    
+  }
+
+  .translate-bar_notice {
     @media #{$small-only} {
       line-height: 1.25;
-      .margin-bottom--half {
-        margin-bottom: 10px !important;
-      }
+      margin-bottom: 10px !important;
     }
   }
 
-  &_message, &_learn {
+  .translate-bar_message,
+  .translate-bar_learn {
     @media #{$small-only} {
       font-size: 0.75rem;
     }
   }
 
-  &_languages {
-    margin: 0;
+  .translate-bar_languages {
+    margin: 0 !important;
+
     > li {
       margin-left: 2rem;
     }
+
     @media #{$small-only} {
       > li {
         font-size: 0.9rem;

--- a/src/materials/02-molecules/headers/translate-bar.html
+++ b/src/materials/02-molecules/headers/translate-bar.html
@@ -1,13 +1,13 @@
 <div class="translate-bar bar bg-tuatara">
   <div class="row">
-    <div class="small-12 medium-6 columns translate-bar_notice">
+    <div class="small-12 medium-7 columns translate-bar_notice-column">
       <!-- in the web app, this whole section gets hidden if selected on English -->
-      <div class="margin-bottom--half">
-        <span class="translate-bar_message c-white t-small t-semi">This page has been translated with Google Translate.</span>
+      <div class="translate-bar_notice">
+        <span class="translate-bar_message c-white t-small t-semi">Esta página ha sido traducida por Google Translate.</span>
         <a href="#" class="translate-bar_learn lined c-white t-small">Learn more.</a>
       </div>
     </div>
-    <div class="small-12 medium-6 columns">
+    <div class="small-12 medium-5 columns">
       <ul class="inline-list translate-bar_languages t-semi right">
         <li><a href="#" class="{{#if english}}active{{/if}}">English</a></li>
         <li><a href="#" class="{{#if spanish}}active{{/if}}">Espanol</a></li>

--- a/src/materials/02-molecules/headers/translate-bar.html
+++ b/src/materials/02-molecules/headers/translate-bar.html
@@ -1,13 +1,13 @@
 <div class="translate-bar bar bg-tuatara">
   <div class="row">
-    <div class="translate-bar_notice-column small-12 medium-7 columns">
+    <div class="translate-bar_notice-column small-12 medium-6 columns">
       <!-- in the web app, this whole section gets hidden if selected on English -->
       <div class="translate-bar_notice">
         <span class="translate-bar_message c-white t-small t-semi">Esta página ha sido traducida por Google Translate.</span>
         <a href="#" class="translate-bar_learn lined c-white t-small">Learn more.</a>
       </div>
     </div>
-    <div class="small-12 medium-5 columns">
+    <div class="small-12 medium-6 columns">
       <ul class="translate-bar_languages inline-list t-semi right">
         <li><a href="#" class="{{#if english}}active{{/if}}">English</a></li>
         <li><a href="#" class="{{#if spanish}}active{{/if}}">Espanol</a></li>

--- a/src/materials/02-molecules/headers/translate-bar.html
+++ b/src/materials/02-molecules/headers/translate-bar.html
@@ -1,6 +1,6 @@
 <div class="translate-bar bar bg-tuatara">
   <div class="row">
-    <div class="small-12 medium-7 columns translate-bar_notice-column">
+    <div class="translate-bar_notice-column small-12 medium-7 columns">
       <!-- in the web app, this whole section gets hidden if selected on English -->
       <div class="translate-bar_notice">
         <span class="translate-bar_message c-white t-small t-semi">Esta página ha sido traducida por Google Translate.</span>
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="small-12 medium-5 columns">
-      <ul class="inline-list translate-bar_languages t-semi right">
+      <ul class="translate-bar_languages inline-list t-semi right">
         <li><a href="#" class="{{#if english}}active{{/if}}">English</a></li>
         <li><a href="#" class="{{#if spanish}}active{{/if}}">Espanol</a></li>
         <li><a href="#" class="{{#if chinese}}active{{/if}} t-ch">中国</a></li>

--- a/src/materials/02-molecules/navigation/top-bar--account.html
+++ b/src/materials/02-molecules/navigation/top-bar--account.html
@@ -2,7 +2,7 @@
   <div class="row">
     <ul class="title-area">
       <li class="name">
-        <h1 class="name-logo offset-up t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
+        <h1 class="name-logo is-tall is-offset-up t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
       </li>
       <li class="toggle-topbar menu-icon">
         <button href="#" class="button-link t-caps t-bold">
@@ -11,7 +11,7 @@
         </button>
       </li>
     </ul>
-    <section class="top-bar-section flex-items">
+    <section class="top-bar-section has-flex-items">
       <ul class="nav-menu right">
         <li>
           <a href="/browse/browse-grid--default.html">

--- a/src/materials/02-molecules/navigation/top-bar--account.html
+++ b/src/materials/02-molecules/navigation/top-bar--account.html
@@ -2,7 +2,7 @@
   <div class="row">
     <ul class="title-area">
       <li class="name">
-        <h1 class="name-logo t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
+        <h1 class="name-logo offset-up t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
       </li>
       <li class="toggle-topbar menu-icon">
         <button href="#" class="button-link t-caps t-bold">
@@ -11,7 +11,7 @@
         </button>
       </li>
     </ul>
-    <section class="top-bar-section">
+    <section class="top-bar-section flex-items">
       <ul class="nav-menu right">
         <li>
           <a href="/browse/browse-grid--default.html">

--- a/src/materials/02-molecules/navigation/top-bar--full.html
+++ b/src/materials/02-molecules/navigation/top-bar--full.html
@@ -2,11 +2,11 @@
   <div class="row">
   <ul class="title-area">
     <li class="name">
-      <div class="name-logo no-offset t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
+      <div class="name-logo t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
     </li>
   </ul>
   <section class="top-bar-section">
-    <ul class="nav-menu no-max-width-items left">
+    <ul class="nav-menu left">
       <li>
         <a href="/lease-up/listings.html">
           Listings
@@ -29,7 +29,7 @@
       </li>
     </ul>
 
-    <ul class="nav-menu no-max-width-items right">
+    <ul class="nav-menu right">
       <li>
         <a href="/pages/get-assistance.html">
           Sign Out

--- a/src/materials/02-molecules/navigation/top-bar--full.html
+++ b/src/materials/02-molecules/navigation/top-bar--full.html
@@ -2,7 +2,7 @@
   <div class="row">
   <ul class="title-area">
     <li class="name">
-      <div class="name-logo t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
+      <div class="name-logo is-short t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
     </li>
   </ul>
   <section class="top-bar-section">

--- a/src/materials/02-molecules/navigation/top-bar--translation.html
+++ b/src/materials/02-molecules/navigation/top-bar--translation.html
@@ -2,7 +2,7 @@
   <div class="row">
     <ul class="title-area">
       <li class="name">
-        <h1 class="name-logo offset-up t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
+        <h1 class="name-logo is-tall is-offset-up t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
       </li>
       <li class="toggle-topbar menu-icon">
         <button href="#" class="button-link t-caps t-bold">
@@ -11,7 +11,7 @@
         </button>
       </li>
     </ul>
-    <section class="top-bar-section flex-items">
+    <section class="top-bar-section has-flex-items">
       <ul class="nav-menu right">
         <li>
           <a href="/browse/browse-grid--default.html">

--- a/src/materials/02-molecules/navigation/top-bar--translation.html
+++ b/src/materials/02-molecules/navigation/top-bar--translation.html
@@ -2,7 +2,7 @@
   <div class="row">
     <ul class="title-area">
       <li class="name">
-        <h1 class="name-logo t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
+        <h1 class="name-logo offset-up t-alt-sans"><a href="/pages/home.html">SF Affordable Housing Portal</a></h1>
       </li>
       <li class="toggle-topbar menu-icon">
         <button href="#" class="button-link t-caps t-bold">
@@ -11,7 +11,7 @@
         </button>
       </li>
     </ul>
-    <section class="top-bar-section">
+    <section class="top-bar-section flex-items">
       <ul class="nav-menu right">
         <li>
           <a href="/browse/browse-grid--default.html">

--- a/src/materials/02-molecules/navigation/top-bar.html
+++ b/src/materials/02-molecules/navigation/top-bar.html
@@ -2,7 +2,7 @@
   <div class="row">
   <ul class="title-area">
     <li class="name">
-      <div class="name-logo t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
+      <div class="name-logo offset-up t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
     </li>
 
     <li class="toggle-topbar menu-icon">
@@ -12,7 +12,7 @@
       </button>
       </li>
   </ul>
-  <section class="top-bar-section">
+  <section class="top-bar-section flex-items">
     <ul class="nav-menu right">
       <li>
         <a href="/browse/browse-grid--default.html">

--- a/src/materials/02-molecules/navigation/top-bar.html
+++ b/src/materials/02-molecules/navigation/top-bar.html
@@ -2,7 +2,7 @@
   <div class="row">
   <ul class="title-area">
     <li class="name">
-      <div class="name-logo offset-up t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
+      <div class="name-logo is-tall is-offset-up t-alt-sans"><a title="DAHLIA San Francisco Housing Portal" href="/pages/home.html">DAHLIA San Francisco Housing Portal</a></div>
     </li>
 
     <li class="toggle-topbar menu-icon">
@@ -12,7 +12,7 @@
       </button>
       </li>
   </ul>
-  <section class="top-bar-section flex-items">
+  <section class="top-bar-section has-flex-items">
     <ul class="nav-menu right">
       <li>
         <a href="/browse/browse-grid--default.html">


### PR DESCRIPTION
Modifying navigation to use flexbox items as a modifier rather than the default setting to allow for reuse.

1. Isolated all flex-box attributes under a single utility class .has-flex-items
      - added .has-flex-items to Webapp navigation .top-bar-section elements
      - removed .no-max-width-items classes
2. Created a utility to control logo offset when .version-bar is present
      - .is-offset-up
3. Created a utility to control logo size
   - .is-tall
3. Fixed mobile spacing on translation menu

Webapp: https://github.com/Exygy/sf-dahlia-web/pull/1038
LAP: https://github.com/Exygy/sf-dahlia-lap/pull/28

Note these updates to master not lap-leaseup