### PR TITLE
Buttons for tabs

### DIFF
--- a/src/assets/toolkit/styles/atoms/_button.scss
+++ b/src/assets/toolkit/styles/atoms/_button.scss
@@ -18,6 +18,18 @@ $button-radius: rem-calc(4);
   }
 }
 
+@mixin button-unstyled($color: $primary, $padding: 0) {
+  background: transparent;
+  border-width: 0;
+  color: $color;
+  display: inline;
+  letter-spacing: normal;
+  padding: $padding;
+  margin-bottom: 0;
+  text-transform: none;
+  border-radius: 0;
+}
+
 // Inverted buttons
 @mixin custom-button-light($cb-light-color: $primary) {
   background-color: $white;
@@ -297,17 +309,15 @@ button,
   }
 
   // Remove button styles
+
+  &.button-unstyled {
+    @include button-unstyled;
+  }
+
   &.button-link {
-    background: transparent;
-    border-width: 0;
-    color: $primary;
-    display: inline;
+    @include button-unstyled;
     font-family: $font-family;
     font-weight: $t-regular !important;
-    letter-spacing: normal;
-    padding: 0;
-    margin-bottom: 0;
-    text-transform: none;
     text-align: left;
 
     svg use {

--- a/src/assets/toolkit/styles/molecules/_tabs.scss
+++ b/src/assets/toolkit/styles/molecules/_tabs.scss
@@ -2,26 +2,28 @@
 // Tabs
 //
 
-.tabs dd > a, 
-.tabs .tab-title > a {
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-weight: $t-semi;
-}
+.tabs dd, 
+.tabs .tab-title {
+  > a,
+  > button {
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-weight: $t-semi;
 
-.tabs dd.active > a, 
-.tabs .tab-title.active > a {
-  box-shadow: inset 0 2px 0 0 $primary;
-
-  &:hover {
-    box-shadow: inset 0 2px 0 0 $primary;
+    &:hover {
+      color: $jet;
+      box-shadow: inset 0 -2px 0 0 $primary;
+    }
   }
-}
 
-.tabs dd > a:hover, 
-.tabs .tab-title > a:hover {
-  color: $jet;
-  box-shadow: inset 0 -2px 0 0 $primary;
+  &.active > a,
+  &.active > button {
+    box-shadow: inset 0 2px 0 0 $primary;
+
+    &:hover {
+      box-shadow: inset 0 2px 0 0 $primary;
+    }
+  }
 }
 
 // Small full width
@@ -30,24 +32,23 @@
     &.tabs dd, 
     &.tabs .tab-title {
       width: 100%;
-    }
 
-    &.tabs dd > a, 
-    &.tabs .tab-title > a {
-      text-align: center;
-    }
+      > a,
+      > button {
+        text-align: center;
 
-    &.tabs dd > a:hover, 
-    &.tabs .tab-title > a:hover {
-      box-shadow: none;
-    }
+        &:hover {
+          box-shadow: none;
+        }
+      }
 
-    &.tabs dd.active > a, 
-    &.tabs .tab-title.active > a {
-      box-shadow: none;
-
-      &:hover {
+      &.active > a,
+      &.active > button {
         box-shadow: none;
+
+        &:hover {
+          box-shadow: none;
+        }
       }
     }
   }

--- a/src/assets/toolkit/styles/molecules/_tabs.scss
+++ b/src/assets/toolkit/styles/molecules/_tabs.scss
@@ -6,10 +6,15 @@
 .tabs .tab-title {
   > a,
   > button {
+    display: block;
+    font-size: $tabs-navigation-font-size;
+    background-color: $tabs-navigation-bg-color;
+    padding: $tabs-navigation-padding $tabs-navigation-padding * 2;
+    color: $tabs-navigation-font-color;
     text-transform: uppercase;
     letter-spacing: 1px;
     font-weight: $t-semi;
-
+    line-height: $base-line-height;
     &:hover {
       color: $jet;
       box-shadow: inset 0 -2px 0 0 $primary;
@@ -19,7 +24,7 @@
   &.active > a,
   &.active > button {
     box-shadow: inset 0 2px 0 0 $primary;
-
+    color: $tabs-navigation-active-font-color;
     &:hover {
       box-shadow: inset 0 2px 0 0 $primary;
     }

--- a/src/materials/02-molecules/navigation/tabs--menu--buttons.html
+++ b/src/materials/02-molecules/navigation/tabs--menu--buttons.html
@@ -1,0 +1,9 @@
+<ul class="tabs full-width-small-only" role="menubar">
+  {{#each items}}
+  <li class="tab-title{{#if active}} active{{/if}}" role="none"><button class="button-unstyled" role="menuitem" tabindex="{{index}}" aria-selected="{{selected}}">{{{name}}}</button></li>
+    {{else}}
+    {{#each menus.lang}}
+    <li class="tab-title{{#if active}} active{{/if}}" role="none"><button class="button-unstyled" role="menuitem" tabindex="{{index}}" aria-selected="{{selected}}">{{{name}}}</button></li>
+    {{/each}}
+  {{/each}}
+</ul>

--- a/src/materials/02-molecules/navigation/tabs--menu--links.html
+++ b/src/materials/02-molecules/navigation/tabs--menu--links.html
@@ -1,0 +1,9 @@
+<ul class="tabs full-width-small-only" role="menubar">
+  {{#each items}}
+  <li class="tab-title{{#if active}} active{{/if}}" role="none"><a href="#" role="menuitem" tabindex="{{index}}" aria-selected="{{selected}}">{{{name}}}</a></li>
+    {{else}}
+    {{#each menus.lang}}
+    <li class="tab-title{{#if active}} active{{/if}}" role="none"><a href="#" role="menuitem" tabindex="{{index}}" aria-selected="{{selected}}">{{{name}}}</a></li>
+    {{/each}}
+  {{/each}}
+</ul>

--- a/src/materials/02-molecules/navigation/tabs--menu.html
+++ b/src/materials/02-molecules/navigation/tabs--menu.html
@@ -1,9 +1,0 @@
-<ul class="tabs full-width-small-only" role="menubar">
-  {{#each items}}
-  <li class="tab-title{{#if active}} active{{/if}}" role="none"><a href="#" role="menuitem" tabindex="{{index}}" aria-selected="{{selected}}">{{{name}}}</a></li>
-    {{else}}
-    {{#each menus.lang}}
-    <li class="tab-title{{#if active}} active{{/if}}" role="none"><a href="#" role="menuitem" tabindex="{{index}}" aria-selected="{{selected}}">{{{name}}}</a></li>
-    {{/each}}
-  {{/each}}
-</ul>


### PR DESCRIPTION
As per [#162422304](https://www.pivotaltracker.com/story/show/162422304), this PR adds a new pattern for tab menus containing `<button>` elements instead of links.

### Full list of changes

- Renamed Tabs Menu to "Tabs Menu Links"
- Added new "Tabs Menu Buttons" pattern
- Added `button-unstyled` mixin by extracting styles from `button-link`, making it easier to reset button styles going forward
- Refactored `_tabs.scss` to accommodate `button` selectors
- Added default tab styles to `_tabs.scss`

---

@callaghanc Feel free to ask Jesse to review if you feel like he'd be more suited to the task.