### PR TITLE
Fix page includes

### DIFF
--- a/src/views/pages/01-basic-pages/home-menu.html
+++ b/src/views/pages/01-basic-pages/home-menu.html
@@ -2,11 +2,7 @@
 {{> headers.version-bar }}
 {{> navigation.top-bar }}
 
-<section class="splash-header bg-image">
-  <div class="row">
-    {{> hero-header }}
-  </div>
-</section>  
+{{> headers.splash-header }}
 
 <section class="splash-message">
   <div class="splash-message_panel row">

--- a/src/views/pages/01-basic-pages/home-translations.html
+++ b/src/views/pages/01-basic-pages/home-translations.html
@@ -2,11 +2,7 @@
 {{> headers.version-bar }}
 {{> navigation.top-bar--translation }}
 
-<section class="splash-header bg-image">
-  <div class="row">
-    {{> hero-header }}
-  </div>
-</section>  
+{{> headers.splash-header }}
 
 <section class="splash-message">
   <div class="splash-message_panel row">

--- a/src/views/pages/01-basic-pages/home.html
+++ b/src/views/pages/01-basic-pages/home.html
@@ -2,11 +2,9 @@
 {{> headers.version-bar }}
 {{> navigation.top-bar }}
 
-<section class="splash-header bg-image">
-  <div class="row">
-    {{> hero-header }}
-  </div>
-</section>  
+
+{{> headers.splash-header }}
+
 
 <section class="splash-message">
   <div class="splash-message_panel row">


### PR DESCRIPTION
Since I renamed "hero header" to "splash header", I accidentally broke references to it on three places in the "Pages" section upon merging #81.

I would have caught this if I had remembered to run `gulp` before merging. 

It would be nice to prevent these issues with a CI tool for this repo. But that doesn't seem urgent because:

- We don't use any PL markup in production apps
- I'd like to entirely remove this "pages" section from the PL in the future