### PR TITLE
[#162565298] Remove default margin on .numbered-list

### DIFF
--- a/src/assets/toolkit/styles/molecules/_directory-header.scss
+++ b/src/assets/toolkit/styles/molecules/_directory-header.scss
@@ -2,6 +2,10 @@
   padding: 1.5rem 1rem;
   background: $mist;
 
+  .numbered-list {
+    margin: 1.5rem 0;
+  }
+
   @media #{$medium-up} {
   	padding: 4rem 2rem;
   }

--- a/src/assets/toolkit/styles/utilities/_lists.scss
+++ b/src/assets/toolkit/styles/utilities/_lists.scss
@@ -29,8 +29,7 @@
 .numbered-list {
   list-style: none;
   padding: 0;
-  margin: 1.5rem 0;
-
+  margin: 0;
   li {
     position: relative;
     display: block;


### PR DESCRIPTION
Related to exygy/sf-dahlia-web#1130

This PR removes gratuitous spacing from the "Before applying" list when inside a content card.