### PR TITLE
Scroll long app-card navigation on small screens #164807951

### DIFF
--- a/src/assets/toolkit/styles/organisms/_app-card.scss
+++ b/src/assets/toolkit/styles/organisms/_app-card.scss
@@ -192,6 +192,7 @@
 
 .app-card_nav {
   @include scut-padding(1rem .5rem 1.5rem);
+  overflow: scroll;
 
   @media #{$small-only} {
     @include scut-padding(1rem 0 1rem);


### PR DESCRIPTION
Related to Exygy/sf-dahlia-web#1176

![scroll-nav](https://user-images.githubusercontent.com/1328849/55423819-94397f80-5533-11e9-8e60-c84e022881a3.gif)

### Review Instructions

- Visit `organisms.html#app-header` on a small browser window
- Confirm that you can scroll horizontally
