### PR TITLE
Adding styles and classes for narrow splash header with highlighted text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 dist/toolkit
 vendor
 build/
+.DS_Store

--- a/components/02-molecules/headers/splash-header--small.html
+++ b/components/02-molecules/headers/splash-header--small.html
@@ -1,0 +1,7 @@
+<div class="splash-header bg-image">
+  <div class="row">
+    <header class="hero-header narrow text-center">
+      <h1 class="hero-title small c-white">Apply for affordable housing in <span class="hero-title_highlight">San Mateo County<span></h1>
+    </header>
+  </div>
+</div>

--- a/public/toolkit/styles/organisms/_splash.scss
+++ b/public/toolkit/styles/organisms/_splash.scss
@@ -22,12 +22,32 @@
   @media #{$xlarge-up} {
     padding: 6rem 1rem;
   }
+
+  &.narrow {
+    @media #{$medium-up} {
+      padding: 4rem 8rem;
+    }
+
+    @media #{$xlarge-up} {
+      padding: 6rem 11rem;
+    }
+  }
 }
 
 .hero-title {
   letter-spacing: -0.04em;
   @include responsive-text-size(mega);
+
   @media #{$large-up} {
     @include responsive-text-size(giga);
   }
+
+  &.small {
+    @include responsive-text-size(mega);
+  }
+}
+
+.hero-title_highlight {
+  text-decoration: underline;
+  text-decoration-color: $warn;
 }


### PR DESCRIPTION
Adding classes for variants of splash header

- .hero-title .small for smaller text size
- .hero-header .narrow for additional padding on header text
- .hero-title_highlight to create underline text effect