### PR TITLE
Improve footer color contrast #168041905

### DIFF
--- a/components/03-organisms/footer.html
+++ b/components/03-organisms/footer.html
@@ -32,7 +32,7 @@
   <section class="footer-sock bg-ebony padding-top--2x padding-bottom">
     <div class="row">
       <div class="medium-3 large-4 columns small-only-text-center">
-        <span class="c-aluminum">© City & County of San Francisco</span>
+        <span class="c-iron">© City & County of San Francisco</span>
       </div>
       <div class="medium-9 large-8 columns small-only-text-center">
         <ul class="inline-list">

--- a/public/toolkit/styles/organisms/_footer.scss
+++ b/public/toolkit/styles/organisms/_footer.scss
@@ -11,7 +11,7 @@
     overflow: visible;
 
     a {
-      color: $aluminum;
+      color: $iron;
 
       &:focus {
         color: $white;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168041905

Use a lighter color for text in bottom footer bar to improve the contrast and make the footer more accessible.