### PR TITLE
Improve keyboard focus accessibility #168041979

### DIFF
--- a/components/01-atoms/forms/checkbox.html
+++ b/components/01-atoms/forms/checkbox.html
@@ -1,4 +1,6 @@
 <div class="checkbox">
   <input id="{{default name 'peach-pie'}}" type="checkbox" name="{{default name 'peach-pie'}}" {{#if checked }}checked=""{{/if}} tab-index="1" />
-  <label for="{{default name 'peach-pie'}}">{{default text 'Checkbox'}}</label>
+  <label for="{{default name 'peach-pie'}}">{{default text 'Checkbox 1'}}</label>
+  <input id="{{default name 'pear-pie'}}" type="checkbox" name="{{default name 'pear-pie'}}" {{#if checked }}checked=""{{/if}} tab-index="2" />
+  <label for="{{default name 'pear-pie'}}">{{default text 'Checkbox 2'}}</label>
 </div>

--- a/public/toolkit/styles/atoms/_button.scss
+++ b/public/toolkit/styles/atoms/_button.scss
@@ -392,10 +392,8 @@ button,
     }
 
     &:focus {
-      box-shadow: 0 0 0 1px #fff, 0 0 3px 3px $attention-tint;
       color: $primary;
       background: $white;
-      outline: none;
 
       svg use {
         fill: $primary;

--- a/public/toolkit/styles/atoms/_button.scss
+++ b/public/toolkit/styles/atoms/_button.scss
@@ -12,11 +12,11 @@ $button-radius: rem-calc(4);
   text-transform: uppercase;
   white-space: normal;
 
-  // Add custom focus for buttons to avoid double outline, allow for rounding
+  // Add custom focus for buttons to make keyboard focus clearer
   &:focus {
     text-decoration: none;
     outline: none;
-    box-shadow: 0 0 0 7px $attention;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
   }
 }
 

--- a/public/toolkit/styles/atoms/_button.scss
+++ b/public/toolkit/styles/atoms/_button.scss
@@ -12,6 +12,7 @@ $button-radius: rem-calc(4);
   text-transform: uppercase;
   white-space: normal;
 
+  // Add custom focus for buttons to avoid double outline, allow for rounding
   &:focus {
     text-decoration: none;
     outline: none;

--- a/public/toolkit/styles/atoms/_button.scss
+++ b/public/toolkit/styles/atoms/_button.scss
@@ -14,7 +14,8 @@ $button-radius: rem-calc(4);
 
   &:focus {
     text-decoration: none;
-    outline-offset: -2px;
+    outline: none;
+    box-shadow: 0 0 0 7px $attention;
   }
 }
 

--- a/public/toolkit/styles/atoms/_forms.scss
+++ b/public/toolkit/styles/atoms/_forms.scss
@@ -8,8 +8,7 @@ select {
   border-radius: $input-border-radius;
 
   &:focus {
-    outline: none;
-    box-shadow: 0 0 0 7px $attention;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
   }
 
   &.squared {

--- a/public/toolkit/styles/atoms/_forms.scss
+++ b/public/toolkit/styles/atoms/_forms.scss
@@ -8,7 +8,8 @@ select {
   border-radius: $input-border-radius;
 
   &:focus {
-    outline: -webkit-focus-ring-color auto 5px;
+    outline: none;
+    box-shadow: 0 0 0 7px $attention;
   }
 
   &.squared {

--- a/public/toolkit/styles/atoms/_links.scss
+++ b/public/toolkit/styles/atoms/_links.scss
@@ -26,7 +26,7 @@ a, .btn-link {
 
   &:focus {
     text-decoration: underline;
-    outline: 5px auto -webkit-focus-ring-color;
+    outline: 7px solid $attention;
   }
 
   &.has-border {
@@ -63,7 +63,7 @@ a, .btn-link {
 
   @media #{$small-only} {
     padding-top: 1rem;
-  }  
+  }
 }
 
 .edit-link {

--- a/public/toolkit/styles/atoms/_links.scss
+++ b/public/toolkit/styles/atoms/_links.scss
@@ -26,7 +26,8 @@ a, .btn-link {
 
   &:focus {
     text-decoration: underline;
-    outline: 7px solid $attention;
+    outline: none;
+    box-shadow: 0 0 2px 3px $attention;
   }
 
   &.has-border {

--- a/public/toolkit/styles/molecules/_inputs.scss
+++ b/public/toolkit/styles/molecules/_inputs.scss
@@ -31,6 +31,12 @@ input[type="radio"] {
   opacity: 0;
   position: absolute;
   margin-left: -20px;
+
+  &:focus {
+    text-decoration: none;
+    outline: none;
+    box-shadow: 0 0 0 7px $attention;
+  }
 }
 
 .ie9 {
@@ -85,10 +91,6 @@ input[type="radio"]:checked + label::before {
   box-shadow: 0 0 0 2px $color-white, 0 0 0 3px $input-border-color;
 }
 
-input[type="radio"]:focus + label::before {
-  box-shadow: 0 0 0 2px $color-white, 0 0 0 3px $color-primary, 0 0 3px 4px $color-focus, 0 0 7px 4px $color-focus;
-}
-
 input[type="checkbox"]:checked + label::before {
   background-image: url("../images/check.png");
   background-image: url("../images/check.svg");
@@ -96,8 +98,10 @@ input[type="checkbox"]:checked + label::before {
   background-repeat: no-repeat;
 }
 
+
+input[type="radio"]:focus + label::before,
 input[type="checkbox"]:focus + label::before {
-  box-shadow: 0 0 0 1px $color-white, 0 0 3px 4px $color-primary;
+  box-shadow: 0 0 0 2px $color-white, 0 0 0 7px $attention;
 }
 
 input[type="checkbox"]:disabled + label {
@@ -331,6 +335,8 @@ input[type="radio"]:disabled + label::before {
     &:focus {
       background-color: $primary;
       color: #fff;
+      outline: none;
+      box-shadow: 0 0 0 7px $attention;
     }
   }
 

--- a/public/toolkit/styles/molecules/_inputs.scss
+++ b/public/toolkit/styles/molecules/_inputs.scss
@@ -34,8 +34,9 @@ input[type="radio"] {
 
   &:focus {
     text-decoration: none;
+    // Appears to be for the case of no label
     outline: none;
-    box-shadow: 0 0 0 7px $attention;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
   }
 }
 
@@ -97,7 +98,7 @@ input[type="checkbox"]:checked + label::before {
 
 input[type="radio"]:focus + label::before,
 input[type="checkbox"]:focus + label::before {
-    box-shadow: 0 0 0 1px $color-white, 0 0 0 2px $input-border-color, 0 0 0 7px $attention;
+  box-shadow: 0 0 0 1px $color-white, 0 0 0 2px $input-border-color, 0 0 3px 4px $attention;
 }
 
 input[type="checkbox"]:disabled + label {
@@ -332,7 +333,7 @@ input[type="radio"]:disabled + label::before {
       background-color: $primary;
       color: #fff;
       outline: none;
-      box-shadow: 0 0 0 7px $attention;
+      box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
     }
   }
 

--- a/public/toolkit/styles/molecules/_inputs.scss
+++ b/public/toolkit/styles/molecules/_inputs.scss
@@ -60,7 +60,7 @@ input[type="checkbox"] + label::before,
 input[type="radio"] + label::before {
   background: white;
   border-radius: $border-radius;
-  box-shadow: 0 0 0 1px $input-border-color;
+  box-shadow: 0 0 0 1px $color-white, 0 0 0 2px $input-border-color;
   content: '\a0';
   display: inline-block;
   height: 1.25rem;
@@ -72,12 +72,8 @@ input[type="radio"] + label::before {
 }
 
 input[type="radio"] + label::before {
-  box-shadow: 0 0 0 2px #fff, 0 0 0 3px $input-border-color;
   height:1.2rem;
   width: 1.2rem;
-}
-
-input[type="radio"] + label::before {
   border-radius: 100%;
 }
 
@@ -88,7 +84,7 @@ input[type="radio"]:checked + label::before {
 }
 
 input[type="radio"]:checked + label::before {
-  box-shadow: 0 0 0 2px $color-white, 0 0 0 3px $input-border-color;
+  box-shadow: 0 0 0 1px $color-white, 0 0 0 2px $input-border-color;
 }
 
 input[type="checkbox"]:checked + label::before {
@@ -101,7 +97,7 @@ input[type="checkbox"]:checked + label::before {
 
 input[type="radio"]:focus + label::before,
 input[type="checkbox"]:focus + label::before {
-  box-shadow: 0 0 0 2px $color-white, 0 0 0 7px $attention;
+    box-shadow: 0 0 0 1px $color-white, 0 0 0 2px $input-border-color, 0 0 0 7px $attention;
 }
 
 input[type="checkbox"]:disabled + label {


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/168041979)

Corresponding webapp pr: https://github.com/Exygy/sf-dahlia-web/pull/1263
## Known issues
- Button segments are not keyboard accessible, follow-up ticket: [#168589930](https://www.pivotaltracker.com/story/show/168589930)
- Language links at the top are missing top and bottom borders, bottom of nav menu links are also missing the highlight, follow-up ticket: [#168527541](https://www.pivotaltracker.com/story/show/168527541)
## Review instructions (for pattern lib)
1. Go to to the [review app](https://sf-dahlia-pl-keyboard-focus.herokuapp.com/), or run the pattern lib locally
1. Go to the [buttons page](https://sf-dahlia-pl-keyboard-focus.herokuapp.com/components/detail/button-guidelines.html) and verify that when you tab over the buttons they have the new super-visible focus border
1. Check out the various input pages, and verify that all types of inputs have the new keyboard focus outline as well. 
1. Check out several of the pages, e.g. the [home page](https://sf-dahlia-pl-keyboard-focus.herokuapp.com/components/detail/home.html), and tab through them and verify that all the various links have consistent styling.

Here's a checklist of all of the pieces that have been updated
- [ ] Links
- [ ] Buttons
- [ ] Text inputs
- [ ] Radio inputs
- [ ] Checkbox inputs

Not included in the list above: Round buttons, and select fields because they match buttons and text input fields
