### PR TITLE
Add focus to unit features accordion #168041979

### DIFF
--- a/components/02-molecules/stats/stats-toggle--one-br.html
+++ b/components/02-molecules/stats/stats-toggle--one-br.html
@@ -1,9 +1,9 @@
 <div class="stats-toggle margin-bottom">
-  <div class="toggle-box toggler has-toggle">
+  <div class="toggle-box toggler has-toggle" role="button" tabindex="0">
     <div class="toggle-box_label">
       <strong>1 Bedroom</strong>: 6 Units, 639&ndash;900 square feet, Accessible units
     </div>
-    
+
     {{> @icons-base icon="arrow-down" size="small" position="control"}}
   </div>
 

--- a/components/02-molecules/stats/stats-toggle.html
+++ b/components/02-molecules/stats/stats-toggle.html
@@ -1,4 +1,4 @@
-<div class="stats-toggle margin-bottom">
+<div class="stats-toggle margin-bottom" role="button">
   <div class="toggle-box toggler has-toggle">
     <div class="toggle-box_label">
       <strong>Studio</strong>: 1 Unit, 639&ndash;900 square feet, Accessible units

--- a/components/02-molecules/stats/stats-toggle.html
+++ b/components/02-molecules/stats/stats-toggle.html
@@ -1,9 +1,9 @@
-<div class="stats-toggle margin-bottom" role="button">
-  <div class="toggle-box toggler has-toggle">
+<div class="stats-toggle margin-bottom">
+  <div class="toggle-box toggler has-toggle" role="button" tabindex="0">
     <div class="toggle-box_label">
       <strong>Studio</strong>: 1 Unit, 639&ndash;900 square feet, Accessible units
     </div>
-    
+
     {{> @icons-base icon="arrow-down" size="small" position="control"}}
   </div>
 

--- a/public/toolkit/styles/atoms/_button.scss
+++ b/public/toolkit/styles/atoms/_button.scss
@@ -3,6 +3,14 @@
 // .button
 $button-radius: rem-calc(4);
 
+@mixin button-focus-highlight() {
+  &:focus {
+    text-decoration: none;
+    outline: none;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
+  }
+}
+
 @mixin custom-button-styles() {
   @include type-weight(bold);
   @include scut-padding(n 1.5rem);
@@ -13,11 +21,7 @@ $button-radius: rem-calc(4);
   white-space: normal;
 
   // Add custom focus for buttons to make keyboard focus clearer
-  &:focus {
-    text-decoration: none;
-    outline: none;
-    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
-  }
+  @include button-focus-highlight();
 }
 
 @mixin button-unstyled($color: $primary, $padding: 0) {
@@ -425,6 +429,10 @@ button,
       }
     }
   }
+}
+
+[role="button"] {
+  @include button-focus-highlight();
 }
 
 // Adds radius to submits

--- a/public/toolkit/styles/molecules/_stats-list.scss
+++ b/public/toolkit/styles/molecules/_stats-list.scss
@@ -44,13 +44,6 @@
   .has-toggle {
     padding-right: 2rem;
   }
-
-  // Add custom focus for buttons to make keyboard focus clearer
-  &:focus {
-    text-decoration: none;
-    outline: none;
-    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
-  }
 }
 
 //

--- a/public/toolkit/styles/molecules/_stats-list.scss
+++ b/public/toolkit/styles/molecules/_stats-list.scss
@@ -44,6 +44,13 @@
   .has-toggle {
     padding-right: 2rem;
   }
+
+  // Add custom focus for buttons to make keyboard focus clearer
+  &:focus {
+    text-decoration: none;
+    outline: none;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 3px 4px $attention;
+  }
 }
 
 //


### PR DESCRIPTION
Review app: https://sf-dahlia-pl-unit-tab-focus.herokuapp.com/
Relevant component: https://sf-dahlia-pl-unit-tab-focus.herokuapp.com/components/detail/stats-toggle--default

I wasn't able to get it to be tabbable in the pattern library, but you can check that the focus is right by modifying the css

![image](https://user-images.githubusercontent.com/11825994/65563399-4c9e1a00-defe-11e9-9c36-326c5088b437.png)
