### PR TITLE
Bugs/spanish pricing table formatting #170459019

### DIFF
--- a/components/01-atoms/tables/pricing-table-listing--sale-with-no-parking.html
+++ b/components/01-atoms/tables/pricing-table-listing--sale-with-no-parking.html
@@ -17,7 +17,7 @@
         <tbody>
         {{#each units}}
         <tr>
-          <td data-th="Availability" class="is-subtitled">
+          <td data-th="Availability" class="is-subtitled availability">
             {{#if waitlist}}
               <small class="pricing-table-waitlist">Waitlist</small>
             {{else}}

--- a/components/01-atoms/tables/pricing-table-listing--sale-with-parking-lease.html
+++ b/components/01-atoms/tables/pricing-table-listing--sale-with-parking-lease.html
@@ -22,7 +22,7 @@
         <tbody>
         {{#each units}}
         <tr>
-          <td data-th="Availability" class="is-subtitled">
+          <td data-th="Availability" class="is-subtitled availability">
             {{#if waitlist}}
               <small class="pricing-table-waitlist">Waitlist</small>
             {{else}}

--- a/components/01-atoms/tables/pricing-table-listing--sale-with-parking.html
+++ b/components/01-atoms/tables/pricing-table-listing--sale-with-parking.html
@@ -22,7 +22,7 @@
         <tbody>
         {{#each units}}
         <tr>
-          <td data-th="Availability" class="is-subtitled">
+          <td data-th="Availability" class="is-subtitled availability">
             {{#if waitlist}}
               <small class="pricing-table-waitlist">Waitlist</small>
             {{else}}

--- a/components/01-atoms/tables/pricing-table-listing--sro.html
+++ b/components/01-atoms/tables/pricing-table-listing--sro.html
@@ -1,5 +1,5 @@
 {{#*inline "tableRow" }}
-<td data-th="Availability" class="is-subtitled">
+<td data-th="Availability" class="is-subtitled availability">
   {{#if waitlist}}
     <small class="pricing-table-waitlist">Waitlist</small>
   {{else}}

--- a/components/01-atoms/tables/pricing-table-listing.html
+++ b/components/01-atoms/tables/pricing-table-listing.html
@@ -1,5 +1,5 @@
 {{#*inline "tableRow" }}
-<td data-th="Availability" class="is-subtitled">
+<td data-th="Availability" class="is-subtitled availability">
   {{#if waitlist}}
     <small class="pricing-table-waitlist">Waitlist</small>
   {{else}}

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -506,7 +506,7 @@ table {
     @include responsive-text-size('base');
     font-feature-settings: "tnum";
 
-    &[data-th="Availability"] {
+    &.availability {
       width: 7rem;
     }
   }
@@ -614,7 +614,7 @@ table {
         text-align: left;
       }
 
-      &[data-th="Availability"]::before {
+      &.availability::before {
         content: "";
       }
     }
@@ -626,7 +626,7 @@ table {
       margin-top: -0.5rem;
     }
 
-    td[data-th="Availability"] {
+    td.availability {
       text-align: right;
       width: 100%;
 


### PR DESCRIPTION
Fix an issue with the formatting of the pricing table when the user selects Spanish as the site language: https://www.pivotaltracker.com/story/show/170459019

This required altering a style that depended on a data attribute that itself is translated, so when a non-English language is selected, the style was not applied. This PR contains the CSS and markup changes needed to remove this dependency.