### PR TITLE
fix pricing table spacing for <small> elements on mobile

### DIFF
--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -603,7 +603,9 @@ table {
 
     small {
       display: inline;
-      margin-left: 0.125rem;
+      &::before {
+        content: "\00a0";
+      }
     }
 
     th {


### PR DESCRIPTION
add ::before content to <small> elements in pricing tables at smallest viewport size rather than using margin-left.