### PR TITLE
Add class for table-nested-rent #172594819

### DIFF
--- a/components/01-atoms/tables/pricing-table-new.html
+++ b/components/01-atoms/tables/pricing-table-new.html
@@ -24,13 +24,29 @@
     </tbody>
   </table>
 </td>
-<td data-th="Rent" class="is-subtitled has-nested-sibling">${{this.BMR_Rent_Monthly}} <small>per month</small></td>
+<td data-th="Rent" class="is-subtitled has-nested-sibling cell-show-small-only">
+  ${{this.BMR_Rent_Monthly}} <small>per month</small>
+</td>
+<td data-th="Rent" class="is-nested cell-hide-small-only">
+  <table class="table-nested-rent">
+    <thead>
+      <tr><th>Rent</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td class="text-right">
+            ${{this.BMR_Rent_Monthly}} <small>per month</small>
+          </td>
+        </tr>
+    </tbody>
+  </table>
+</td>
 {{/inline}}
 
 {{#if reserved}}
 <div class="message-group">
   <div class="message is-reserved">
-    <span class="message-text">Reserved units for People with Developental Disabilities</span>  
+    <span class="message-text">Reserved units for People with Developmental Disabilities</span>
   </div>
 </div>
 {{/if}}

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -569,8 +569,16 @@ table {
   }
 }
 
-.table-nested-income {
+@mixin table-nested {
   margin-bottom: 0;
+
+  tr {
+    border-bottom: none;
+  }
+}
+
+.table-nested-income {
+  @include table-nested;
 
   th {
     text-transform: none;
@@ -582,8 +590,19 @@ table {
   th:last-child {
     text-align: left;
   }
-  tr {
-    border-bottom: none;
+}
+
+.table-nested-rent {
+  @include table-nested;
+
+  th {
+    color: $white;
+  }
+}
+
+@media #{$medium-up} {
+  td.cell-show-small-only {
+    display: none !important;
   }
 }
 
@@ -617,6 +636,10 @@ table {
     td,
     tbody {
       display: block;
+    }
+
+    td.cell-hide-small-only {
+      display: none !important;
     }
 
     tr {


### PR DESCRIPTION
To fix ticket [#172594819](https://www.pivotaltracker.com/n/projects/1405352/stories/172594819) we need to make the rent column a nested table
in the same way the income column is. This change adds the styles
necessary for that.

Webapp pr: https://github.com/SFDigitalServices/sf-dahlia-web/pull/1354

The nested table in the rent column includes a whitout-ed header with the word "rent" so it is read out in jaws. See [this conversation](https://sfdigitalservices.slack.com/archives/CCHRVN7AB/p1592254070005200) where Christina says the existing solution doesn't work in windows.

## Screenshot: local pattern library build (small screen)
![- 2020-06-17 at 4 29 47 PM](https://user-images.githubusercontent.com/64036574/84961947-6732a780-b0ba-11ea-85cc-39b46a01e965.png)

## Screenshot: local pattern library build (large screen)
![- 2020-06-17 at 4 30 27 PM](https://user-images.githubusercontent.com/64036574/84961967-70bc0f80-b0ba-11ea-9fcd-a671cf681163.png)



