### PR TITLE
[Pattern] Fix income label overlap #172562390

### DIFF
--- a/components/01-atoms/tables/pricing-table-new--ownership.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership.html
@@ -5,8 +5,18 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
   {{total}} <small>available</small>
+</td>
+<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+  <table class="table-nested-units">
+    <thead>
+      <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>{{total}} <small>available</small></td></tr>
+    </tbody>
+  </table>
 </td>
 <td data-th="Income Range" class="is-supertitled is-nested">
   <table class="table-nested-income">
@@ -78,7 +88,9 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level"><td class="income-level-label">{{this.incomeLevel}}</td></tr>
+        <tr class="income-level row-show-small-only">
+          <td class="income-level-label">{{this.incomeLevel}}</td>
+        </tr>
         {{#each this.priceGroups}}
           <tr>{{> tableRow whiteout=@../index}}</tr>
         {{/each}}

--- a/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
@@ -5,8 +5,18 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
   {{total}} <small>available</small>
+</td>
+<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+  <table class="table-nested-units">
+    <thead>
+      <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>{{total}} <small>available</small></td></tr>
+    </tbody>
+  </table>
 </td>
 <td data-th="Income Range" class="is-supertitled is-nested">
   <table class="table-nested-income">
@@ -62,7 +72,9 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level"><td class="income-level-label">{{this.incomeLevel}}</td></tr>
+        <tr class="income-level row-show-small-only">
+          <td class="income-level-label">{{this.incomeLevel}}</td>
+        </tr>
         {{#each this.priceGroups}}
           <tr>{{> tableRow whiteout=@../index}}</tr>
         {{/each}}

--- a/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
@@ -5,8 +5,18 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
   {{total}} <small>available</small>
+</td>
+<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+  <table class="table-nested-units">
+    <thead>
+      <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>{{total}} <small>available</small></td></tr>
+    </tbody>
+  </table>
 </td>
 <td data-th="Income Range" class="is-supertitled is-nested">
   <table class="table-nested-income">
@@ -57,7 +67,9 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level"><td class="income-level-label">{{this.incomeLevel}}</td></tr>
+        <tr class="income-level row-show-small-only">
+          <td class="income-level-label">{{this.incomeLevel}}</td>
+        </tr>
         {{#each this.priceGroups}}
           <tr>{{> tableRow whiteout=@../index}}</tr>
         {{/each}}

--- a/components/01-atoms/tables/pricing-table-new.config.json
+++ b/components/01-atoms/tables/pricing-table-new.config.json
@@ -149,6 +149,7 @@
                 "HOA_Dues_With_Parking": 475,
                 "Max_AMI_for_Qualifying_Unit": 100,
                 "Min_Occupancy": 1,
+                "Planning_AMI_Tier": "Low Income",
                 "Status": "Available",
                 "total": 2,
                 "incomeLimits": [
@@ -191,6 +192,7 @@
                 "HOA_Dues_With_Parking": 500,
                 "Max_AMI_for_Qualifying_Unit": 100,
                 "Min_Occupancy": 2,
+                "Planning_AMI_Tier": "Low Income",
                 "Status": "Available",
                 "total": 5,
                 "incomeLimits": [
@@ -209,6 +211,44 @@
                   {
                     "occupancy": 4,
                     "maxIncome": "10263",
+                    "minIncome": "None",
+                    "noMin": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "incomeLevel": "Moderate Income",
+            "priceGroups": [
+              {
+                "Unit_Type": "2 BR",
+                "BMR_Rental_Minimum_Monthly_Income_Needed": 0,
+                "Price_Without_Parking": 500050,
+                "Price_With_Parking": 446948,
+                "HOA_Dues_Without_Parking": 450,
+                "HOA_Dues_With_Parking": 500,
+                "Max_AMI_for_Qualifying_Unit": 100,
+                "Min_Occupancy": 2,
+                "Planning_AMI_Tier": "Moderate Income",
+                "Status": "Available",
+                "total": 2,
+                "incomeLimits": [
+                  {
+                    "occupancy": 2,
+                    "maxIncome": "10208",
+                    "minIncome": "None",
+                    "noMin": true
+                  },
+                  {
+                    "occupancy": 3,
+                    "maxIncome": "11238",
+                    "minIncome": "None",
+                    "noMin": true
+                  },
+                  {
+                    "occupancy": 4,
+                    "maxIncome": "12263",
                     "minIncome": "None",
                     "noMin": true
                   }

--- a/components/01-atoms/tables/pricing-table-new.html
+++ b/components/01-atoms/tables/pricing-table-new.html
@@ -5,8 +5,18 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
   {{this.total}} <small>available</small>
+</td>
+<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+  <table class="table-nested-units">
+    <thead>
+      <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>{{this.total}} <small>available</small></td></tr>
+    </tbody>
+  </table>
 </td>
 <td data-th="Income Range" class="is-supertitled is-nested">
   <table class="table-nested-income">
@@ -64,7 +74,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level">
+        <tr class="income-level row-show-small-only">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -513,6 +513,7 @@ table {
       }
     }
     &.income-level {
+      box-sizing: content-box;
       border-bottom: none;
     }
   }
@@ -528,7 +529,6 @@ table {
     }
 
     &.income-level-label {
-      position: absolute;
       @include income-label-style;
     }
 

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -2,6 +2,12 @@ $td-reserved-light: lighten($splash-tint, 10%);
 $td-reserved-lighter: lighten($splash-tint, 11%);
 $td-reserved-inset: inset 3px 0px 0px 0px rgba(255,102,39,1);
 
+@mixin income-label-style {
+  color: $charcoal;
+  font-family: $alt-font-family;
+  @include responsive-text-size('small');
+}
+
 .th {
   font-weight: $table-value-weight;
   letter-spacing: .1rem;
@@ -523,8 +529,7 @@ table {
 
     &.income-level-label {
       position: absolute;
-      font-family: $alt-font-family;
-      @include responsive-text-size('small');
+      @include income-label-style;
     }
 
     &.has-nested-sibling {
@@ -569,11 +574,29 @@ table {
   }
 }
 
+.table-cell-units {
+  width: 100px;
+}
+
 @mixin table-nested {
   margin-bottom: 0;
 
   tr {
     border-bottom: none;
+  }
+}
+
+.table-nested-units {
+  @include table-nested;
+
+  th {
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  th:last-child {
+    text-align: left;
+    @include income-label-style;
   }
 }
 
@@ -602,6 +625,10 @@ table {
 
 @media #{$medium-up} {
   td.cell-show-small-only {
+    display: none !important;
+  }
+
+  tr.row-show-small-only {
     display: none !important;
   }
 }


### PR DESCRIPTION
Separate the income labels for small and large devices so that on large
devices the label can wrap properly based on cell width.

I decided to make the units cell fixed-width because before the width was based on the longest text in the cell, which used to always be the word "available" so this column always had the same width for every table on the page. Now, since the income text is part of the cell and is really variable, these cell widths look inconsistent across the page unless they are set to a fixed value.

## Screenshot: Rentals on large screens
<img src="https://user-images.githubusercontent.com/64036574/85072430-fa78e500-b16d-11ea-8945-dfbd079ba3fe.png" width="630" />

## Screenshot: Rentals on small screens
<img src="https://user-images.githubusercontent.com/64036574/85072418-f2b94080-b16d-11ea-84b7-cf23cf1f4e94.png" width="330" />

## Screenshot: sale listings on large screens
<img src="https://user-images.githubusercontent.com/64036574/85072645-462b8e80-b16e-11ea-92a0-49804e8d53d5.png" width="630" />

## Screenshot: Sale on small screens
<img src="https://user-images.githubusercontent.com/64036574/85072453-01075c80-b16e-11ea-8ff1-9c2a2ec51ec8.png" width="330" />
