### PR TITLE
[Pattern Library] Fix squished sale listings #173618329

### DIFF
--- a/components/01-atoms/tables/pricing-table-new--ownership.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership.html
@@ -77,7 +77,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper with-mobile-pricing-on-tablet with-mobile-pricing-on-tablet">
+<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>

--- a/components/01-atoms/tables/pricing-table-new--ownership.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership.html
@@ -77,7 +77,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
+<div class="table-pricing-wrapper with-mobile-styling-at-large-breakpoint">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>

--- a/components/01-atoms/tables/pricing-table-new--ownership.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
   {{total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -77,7 +77,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper">
+<div class="table-pricing-wrapper with-mobile-pricing-on-tablet with-mobile-pricing-on-tablet">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>
@@ -88,7 +88,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-show-small-only">
+        <tr class="income-level row-hide-large-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new--ownership.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-xlarge-up">
   {{total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
+<td data-th="Units" class="is-nested table-cell-units cell-show-xlarge-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -88,7 +88,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-hide-large-up">
+        <tr class="income-level row-hide-xlarge-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-xlarge-up">
   {{total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
+<td data-th="Units" class="is-nested table-cell-units cell-show-xlarge-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -72,7 +72,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-hide-large-up">
+        <tr class="income-level row-hide-xlarge-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
   {{total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -61,7 +61,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper">
+<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>
@@ -72,7 +72,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-show-small-only">
+        <tr class="income-level row-hide-large-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
@@ -61,7 +61,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
+<div class="table-pricing-wrapper with-mobile-styling-at-large-breakpoint">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>

--- a/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
@@ -56,7 +56,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
+<div class="table-pricing-wrapper with-mobile-styling-at-large-breakpoint">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>

--- a/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
   {{total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -56,7 +56,7 @@
 
 {{#each ownershipUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper">
+<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
   <table class="table-pricing top-align" role="grid">
     <thead>
       <tr>
@@ -67,7 +67,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-show-small-only">
+        <tr class="income-level row-hide-large-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-xlarge-up">
   {{total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
+<td data-th="Units" class="is-nested table-cell-units cell-show-xlarge-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -67,7 +67,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-hide-large-up">
+        <tr class="income-level row-hide-xlarge-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new.html
+++ b/components/01-atoms/tables/pricing-table-new.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-xlarge-up">
   {{this.total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
+<td data-th="Units" class="is-nested table-cell-units cell-show-xlarge-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -34,10 +34,10 @@
     </tbody>
   </table>
 </td>
-<td data-th="Rent" class="is-subtitled has-nested-sibling cell-hide-large-up">
+<td data-th="Rent" class="is-subtitled has-nested-sibling cell-hide-xlarge-up">
   ${{this.BMR_Rent_Monthly}} <small>per month</small>
 </td>
-<td data-th="Rent" class="is-nested cell-show-large-up">
+<td data-th="Rent" class="is-nested cell-show-xlarge-up">
   <table class="table-nested-rent">
     <thead>
       <tr><th>Rent</th></tr>
@@ -74,7 +74,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-hide-large-up">
+        <tr class="income-level row-hide-xlarge-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/components/01-atoms/tables/pricing-table-new.html
+++ b/components/01-atoms/tables/pricing-table-new.html
@@ -63,7 +63,7 @@
 
 {{#each rentalUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
+<div class="table-pricing-wrapper with-mobile-styling-at-large-breakpoint">
   <table class="table-pricing table-pricing-rent top-align" role="grid">
     <thead>
       <tr>

--- a/components/01-atoms/tables/pricing-table-new.html
+++ b/components/01-atoms/tables/pricing-table-new.html
@@ -5,10 +5,10 @@
 {{/inline}}
 
 {{#*inline "tableRow"}}
-<td data-th="Units" class="is-subtitled has-nested-sibling cell-show-small-only">
+<td data-th="Units" class="is-subtitled has-nested-sibling cell-hide-large-up">
   {{this.total}} <small>available</small>
 </td>
-<td data-th="Units" class="is-nested table-cell-units cell-hide-small-only">
+<td data-th="Units" class="is-nested table-cell-units cell-show-large-up">
   <table class="table-nested-units">
     <thead>
       <tr><th>{{this.Planning_AMI_Tier}}</th></tr>
@@ -34,10 +34,10 @@
     </tbody>
   </table>
 </td>
-<td data-th="Rent" class="is-subtitled has-nested-sibling cell-show-small-only">
+<td data-th="Rent" class="is-subtitled has-nested-sibling cell-hide-large-up">
   ${{this.BMR_Rent_Monthly}} <small>per month</small>
 </td>
-<td data-th="Rent" class="is-nested cell-hide-small-only">
+<td data-th="Rent" class="is-nested cell-show-large-up">
   <table class="table-nested-rent">
     <thead>
       <tr><th>Rent</th></tr>
@@ -63,7 +63,7 @@
 
 {{#each rentalUnits}}
 <h2 class="table-pricing-ami">{{this.type}}</h2>
-<div class="table-pricing-wrapper">
+<div class="table-pricing-wrapper with-mobile-pricing-on-tablet">
   <table class="table-pricing table-pricing-rent top-align" role="grid">
     <thead>
       <tr>
@@ -74,7 +74,7 @@
     </thead>
     <tbody>
       {{#each this.incomeLevels}}
-        <tr class="income-level row-show-small-only">
+        <tr class="income-level row-hide-large-up">
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -642,16 +642,22 @@ table {
 }
 
 @media #{$large-up} {
-  td.cell-show-small-only {
+  td.cell-hide-large-up {
     display: none !important;
   }
 
-  tr.row-show-small-only {
+  tr.row-hide-large-up {
     display: none !important;
   }
 }
 
 @media #{$small-only}, #{$medium-only} {
+  td.cell-show-large-up {
+    display: none !important;
+  }
+}
+
+@mixin mobile-table-styling {
   .table-pricing-wrapper {
     margin-top: 0;
   }
@@ -681,10 +687,6 @@ table {
     td,
     tbody {
       display: block;
-    }
-
-    td.cell-hide-small-only {
-      display: none !important;
     }
 
     tr {
@@ -740,7 +742,6 @@ table {
       &.is-nested {
         padding-left: 1rem;
       }
-
     }
 
     i {
@@ -798,5 +799,15 @@ table {
 
   .pricing-table-waitlist {
     padding: 0.5rem 0;
+  }
+}
+
+@media #{$small-only} {
+  @include mobile-table-styling()
+}
+
+@media #{$medium-only} {
+  .with-mobile-pricing-on-tablet {
+    @include mobile-table-styling()
   }
 }

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -799,7 +799,7 @@ table {
 }
 
 @media (max-width: $large-breakpoint) {
-  .with-mobile-pricing-on-tablet {
+  .with-mobile-styling-at-large-breakpoint {
     @include mobile-table-styling()
   }
 }

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -7,7 +7,7 @@ $td-reserved-inset: inset 3px 0px 0px 0px rgba(255,102,39,1);
   @include text-size($text-size, 'small');
 
   @if map-has-key(text-breakpoints-for($text-size), 'medium') {
-    @include respond-above('large') {
+    @include respond-above('x-large') {
       @include text-size($text-size, 'medium');
     }
   }
@@ -159,7 +159,7 @@ table {
 
   &.td-nowrap {
     tbody tr td {
-      @media #{$large-up} {
+      @media #{$xlarge-up} {
         white-space: nowrap;
       }
     }
@@ -167,7 +167,7 @@ table {
 
   &.th-nowrap {
     thead tr th {
-      @media #{$large-up} {
+      @media #{$xlarge-up} {
         white-space: nowrap;
       }
     }
@@ -286,14 +286,6 @@ table {
 
   .scrollable-table-nested.expand-wide {
     width: calc(100vw - 4rem);
-
-    @media #{$large-up} {
-      width: calc(100vw - 12rem);
-    }
-
-    @media #{$large-up} {
-      width: calc(100vw - 18rem);
-    }
 
     @media #{$xlarge-up} {
       width: auto;
@@ -433,7 +425,7 @@ table {
   }
 
   .td, th {
-    @media #{$small-only}, #{$medium-only} {
+    @media (max-width: $large-breakpoint) {
       padding-left: $table-padding-small;
       padding-right: $table-padding-small;
     }
@@ -641,18 +633,18 @@ table {
   }
 }
 
-@media #{$large-up} {
-  td.cell-hide-large-up {
+@media #{$xlarge-up} {
+  td.cell-hide-xlarge-up {
     display: none !important;
   }
 
-  tr.row-hide-large-up {
+  tr.row-hide-xlarge-up {
     display: none !important;
   }
 }
 
-@media #{$small-only}, #{$medium-only} {
-  td.cell-show-large-up {
+@media (max-width: $large-breakpoint) {
+  td.cell-show-xlarge-up {
     display: none !important;
   }
 }
@@ -806,7 +798,7 @@ table {
   @include mobile-table-styling()
 }
 
-@media #{$medium-only} {
+@media (max-width: $large-breakpoint) {
   .with-mobile-pricing-on-tablet {
     @include mobile-table-styling()
   }

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -2,10 +2,21 @@ $td-reserved-light: lighten($splash-tint, 10%);
 $td-reserved-lighter: lighten($splash-tint, 11%);
 $td-reserved-inset: inset 3px 0px 0px 0px rgba(255,102,39,1);
 
+// AMI table treats medium widths as small, need to use custom responsive text function.
+@mixin responsive-ami-text-size($text-size) {
+  @include text-size($text-size, 'small');
+
+  @if map-has-key(text-breakpoints-for($text-size), 'medium') {
+    @include respond-above('large') {
+      @include text-size($text-size, 'medium');
+    }
+  }
+}
+
 @mixin income-label-style {
   color: $charcoal;
   font-family: $alt-font-family;
-  @include responsive-text-size('small');
+  @include responsive-ami-text-size('small');
 }
 
 .th {
@@ -148,7 +159,7 @@ table {
 
   &.td-nowrap {
     tbody tr td {
-      @media #{$medium-up} {
+      @media #{$large-up} {
         white-space: nowrap;
       }
     }
@@ -156,7 +167,7 @@ table {
 
   &.th-nowrap {
     thead tr th {
-      @media #{$medium-up} {
+      @media #{$large-up} {
         white-space: nowrap;
       }
     }
@@ -276,7 +287,7 @@ table {
   .scrollable-table-nested.expand-wide {
     width: calc(100vw - 4rem);
 
-    @media #{$medium-up} {
+    @media #{$large-up} {
       width: calc(100vw - 12rem);
     }
 
@@ -310,7 +321,7 @@ table {
       }
     }
 
-    // support resverved unit tinting within flexible table
+    // support reserved unit tinting within flexible table
     &.tr-reserved {
       @media #{$small-only} {
         td {
@@ -414,14 +425,21 @@ table {
 // Pricing tables
 
 .table-pricing-ami {
-  @include responsive-text-size('gamma');
+  @include responsive-ami-text-size('gamma');
   position: relative;
 
   .table-pricing-wrapper + & {
     margin-top: 2rem;
   }
 
-  @media #{$medium-up} {
+  .td, th {
+    @media #{$small-only}, #{$medium-only} {
+      padding-left: $table-padding-small;
+      padding-right: $table-padding-small;
+    }
+  }
+
+  @media #{$large-up} {
     @include scut-padding(0 n 0 n);
     background-color: transparent;
     border-bottom: 0;
@@ -441,7 +459,7 @@ table {
   top: 0.25rem;
   left: 0;
   font-family: $alt-font-family;
-  @include responsive-text-size('base');
+  @include responsive-ami-text-size('base');
   line-height: 1;
   font-weight: $t-semi;
 }
@@ -460,14 +478,14 @@ table {
 
   dl {
     font-weight: $t-regular;
-    @include responsive-text-size('base');
+    @include responsive-ami-text-size('base');
     margin: 0;
   }
 
   dt, dd {
     float: left;
     margin-bottom: 0.25rem;
-    @include responsive-text-size('small');
+    @include responsive-ami-text-size('small');
 
     strong {
       font-weight: $t-semi;
@@ -483,7 +501,7 @@ table {
 
   th, td::before {
     color: $steel;
-    @include responsive-text-size('small');
+    @include responsive-ami-text-size('small');
     font-family: $alt-font-family;
   }
 
@@ -520,7 +538,7 @@ table {
 
   td {
     padding: 0.75rem 0;
-    @include responsive-text-size('base');
+    @include responsive-ami-text-size('base');
     font-feature-settings: "tnum";
     vertical-align: top;
 
@@ -537,9 +555,9 @@ table {
     }
   }
 
-  // Number of availably units
+  // Number of available units
   i {
-    @include responsive-text-size('delta');
+    @include responsive-ami-text-size('delta');
     color: $jet;
     font-style: normal;
     font-weight: $t-regular;
@@ -548,7 +566,7 @@ table {
 
   small {
     display: block;
-    @include responsive-text-size('tiny');
+    @include responsive-ami-text-size('tiny');
     color: $steel;
     text-transform: none;
     letter-spacing: 0;
@@ -562,14 +580,14 @@ table {
 
 .table-pricing-rent {
   th:last-child,
-  td[data-th="Rent"], {
+  td[data-th="Rent"] {
     text-align: right;
   }
 }
 
 .table-pricing-sale-lease {
   th:last-child,
-  td[data-th="Optional parking lease"], {
+  td[data-th="Optional parking lease"] {
     text-align: right;
   }
 }
@@ -623,7 +641,7 @@ table {
   }
 }
 
-@media #{$medium-up} {
+@media #{$large-up} {
   td.cell-show-small-only {
     display: none !important;
   }
@@ -633,7 +651,7 @@ table {
   }
 }
 
-@media #{$small-only} {
+@media #{$small-only}, #{$medium-only} {
   .table-pricing-wrapper {
     margin-top: 0;
   }
@@ -726,7 +744,7 @@ table {
     }
 
     i {
-      @include responsive-text-size('base');
+      @include responsive-ami-text-size('base');
       font-weight: $t-semi;
     }
 

--- a/public/toolkit/styles/utilities/_type.scss
+++ b/public/toolkit/styles/utilities/_type.scss
@@ -309,7 +309,7 @@ $text-sizing: (
 }
 
 .t-ch-button {
-  line-height: 1rem; 
+  line-height: 1rem;
   vertical-align: top;
 }
 


### PR DESCRIPTION
[#173618329](https://www.pivotaltracker.com/n/projects/1405352/stories/173618329)

This change makes it so that the AMI tiers table switches to the "mobile view" when at large screen size.

I tried to make sure not to touch other tables with this change.

## Screencast: rental listings switch to mobile view at tablet sizes
<img src="https://user-images.githubusercontent.com/64036574/86961810-b5b1ef80-c116-11ea-97ea-3f90cb937e20.gif" width="330" />

## Screencast: sale listings switch to mobile view at tablet sizes
<img src="https://user-images.githubusercontent.com/64036574/86961840-c1051b00-c116-11ea-8123-4141aa34e056.gif" width="330" />

## Screencast [unchanged]: hero table
<img src="https://user-images.githubusercontent.com/64036574/86961908-ded28000-c116-11ea-9585-0dcf61194104.gif" width="330" />

## Screencast [unchanged]: flex table
<img src="https://user-images.githubusercontent.com/64036574/86961932-e5f98e00-c116-11ea-9766-d4ddd8986e7a.gif" width="330" />

## Screencast [unchanged]: features table
<img src="https://user-images.githubusercontent.com/64036574/86961949-ec880580-c116-11ea-9d96-edad0ccb2f2f.gif" width="330" />

## Screencast: Webapp rental AMI table
<img src="https://user-images.githubusercontent.com/64036574/86964763-71751e00-c11b-11ea-9502-dc02546c15e5.gif" width="530" />

## Screencast: Webapp sale AMI table 
<img src="https://user-images.githubusercontent.com/64036574/86964793-7a65ef80-c11b-11ea-9e9a-8595040601e5.gif" width="530" />

