### PR TITLE
Features/demographics polish #173303363

### DIFF
--- a/components/01-atoms/icons/icon-plus-minus.html
+++ b/components/01-atoms/icons/icon-plus-minus.html
@@ -1,4 +1,4 @@
-<span class="ui-icon ui-{{default position 'static'}} ui-{{ default size 'medium'}} i-{{default fill 'color'}} {{default classes ''}}">
+<span class="ui-icon ui-medium i-color {{default classes ''}}">
   <svg class="ui-minus">
     <use xlink:href="#i-minus"></use>
   </svg>

--- a/components/01-atoms/icons/icon-plus-minus.html
+++ b/components/01-atoms/icons/icon-plus-minus.html
@@ -1,4 +1,4 @@
-<span class="ui-icon ui-medium i-color {{default classes ''}}">
+<span class="ui-icon ui-{{ default size 'medium'}} i-color {{default classes ''}}">
   <svg class="ui-minus">
     <use xlink:href="#i-minus"></use>
   </svg>

--- a/components/02-molecules/components/accordion-plus-minus.html
+++ b/components/02-molecules/components/accordion-plus-minus.html
@@ -4,7 +4,14 @@
       <div class="accordion-header-title">
         Accordion Selection 1
       </div>
-      {{> @icon-plus-minus active="false" position="control"}}
+      <span class="ui-icon ui-medium i-color">
+        <svg class="ui-minus">
+          <use xlink:href="#i-minus"></use>
+        </svg>
+        <svg class="ui-plus">
+          <use xlink:href="#i-plus"></use>
+        </svg>
+      </span>
     </a>
     <div id="panel-1-a" class="content">
       <div class="checkbox-group" role="group">
@@ -41,7 +48,14 @@
       <div class="accordion-header-title">
         Accordion Selection 2
       </div>
-      {{> @icon-plus-minus active="false" position="control"}}
+      <span class="ui-icon ui-medium i-color">
+        <svg class="ui-minus">
+          <use xlink:href="#i-minus"></use>
+        </svg>
+        <svg class="ui-plus">
+          <use xlink:href="#i-plus"></use>
+        </svg>
+      </span>
     </a>
     <div id="panel-1-b" class="content">
       <div class="checkbox-group" role="group">
@@ -90,7 +104,14 @@
       <div class="accordion-header-title">
         Accordion Selection 3 With very long name that should wrap
       </div>
-      {{> @icon-plus-minus active="false" position="control"}}
+      <span class="ui-icon ui-medium i-color">
+        <svg class="ui-minus">
+          <use xlink:href="#i-minus"></use>
+        </svg>
+        <svg class="ui-plus">
+          <use xlink:href="#i-plus"></use>
+        </svg>
+      </span>
     </a>
     <div id="panel-1-c" class="content">
       <div class="checkbox-group" role="group">
@@ -108,12 +129,19 @@
       <div class="accordion-header-title">
         Accordion Selection 4 With very long name that should wrap
       </div>
-      <span class="ui-icon ui-control ui-{{ default size 'medium'}} i-{{default fill 'color'}} {{default classes ''}}">
+      <span class="ui-icon ui-medium i-color">
         <svg class="ui-check">
           <use xlink:href="#i-check"></use>
         </svg>
       </span>
-      {{> @icon-plus-minus active="false" position="control"}}
+      <span class="ui-icon ui-medium i-color">
+        <svg class="ui-minus">
+          <use xlink:href="#i-minus"></use>
+        </svg>
+        <svg class="ui-plus">
+          <use xlink:href="#i-plus"></use>
+        </svg>
+      </span>
     </a>
     <div id="panel-1-d" class="content">
       <div class="checkbox-group" role="group">

--- a/components/02-molecules/components/accordion-plus-minus.html
+++ b/components/02-molecules/components/accordion-plus-minus.html
@@ -1,7 +1,9 @@
 <dl class="accordion-plus-minus accordion trigger-right" data-accordion>
   <dd class="accordion-navigation">
     <a href="#panel-1-a" class="accordion-header" draggable="false">
-      Accordion Selection 1
+      <div class="accordion-header-title">
+        Accordion Selection 1
+      </div>
       {{> @icon-plus-minus active="false" position="control"}}
     </a>
     <div id="panel-1-a" class="content">
@@ -36,7 +38,9 @@
   </dd>
   <dd class="accordion-navigation">
     <a href="#panel-1-b" class="accordion-header" draggable="false">
-      Accordion Selection 2
+      <div class="accordion-header-title">
+        Accordion Selection 2
+      </div>
       {{> @icon-plus-minus active="false" position="control"}}
     </a>
     <div id="panel-1-b" class="content">
@@ -83,7 +87,9 @@
   </dd>
   <dd class="accordion-navigation">
     <a href="#panel-1-c" class="accordion-header" draggable="false">
-      Accordion Selection 3
+      <div class="accordion-header-title">
+        Accordion Selection 3 With very long name that should wrap
+      </div>
       {{> @icon-plus-minus active="false" position="control"}}
     </a>
     <div id="panel-1-c" class="content">
@@ -99,8 +105,10 @@
   </dd>
   <dd class="accordion-navigation">
     <a href="#panel-1-d" class="accordion-header" draggable="false">
-      Accordion Selection 4
-      <span class="ui-icon ui-{{default position 'static'}} ui-{{ default size 'medium'}} i-{{default fill 'color'}} {{default classes ''}}">
+      <div class="accordion-header-title">
+        Accordion Selection 4 With very long name that should wrap
+      </div>
+      <span class="ui-icon ui-control ui-{{ default size 'medium'}} i-{{default fill 'color'}} {{default classes ''}}">
         <svg class="ui-check">
           <use xlink:href="#i-check"></use>
         </svg>

--- a/components/02-molecules/components/accordion-plus-minus.html
+++ b/components/02-molecules/components/accordion-plus-minus.html
@@ -1,11 +1,11 @@
 <dl class="accordion-plus-minus accordion trigger-right" data-accordion>
   <dd class="accordion-navigation">
-    <a href="#panel-1-a" class="accordion-header" draggable="false">
+    <div class="accordion-header" draggable="false">
       <div class="accordion-header-title">
         Accordion Selection 1
       </div>
       {{> @icon-plus-minus active="false" }}
-    </a>
+    </div>
     <div id="panel-1-a" class="content">
       <div class="checkbox-group" role="group">
         <div class="checkbox-block-accordion">
@@ -36,13 +36,13 @@
       </div>
     </div>
   </dd>
-  <dd class="accordion-navigation">
-    <a href="#panel-1-b" class="accordion-header" draggable="false">
+  <dd class="accordion-navigation active">
+    <div class="accordion-header" draggable="false">
       <div class="accordion-header-title">
         Accordion Selection 2
       </div>
       {{> @icon-plus-minus active="false" }}
-    </a>
+    </div>
     <div id="panel-1-b" class="content">
       <div class="checkbox-group" role="group">
         <div class="checkbox-block-accordion">
@@ -86,12 +86,12 @@
     </div>
   </dd>
   <dd class="accordion-navigation">
-    <a href="#panel-1-c" class="accordion-header" draggable="false">
+    <div href="#panel-1-c" class="accordion-header" draggable="false">
       <div class="accordion-header-title">
         Accordion Selection 3 With very long name that should wrap
       </div>
       {{> @icon-plus-minus active="false" }}
-    </a>
+    </div>
     <div id="panel-1-c" class="content">
       <div class="checkbox-group" role="group">
         <div class="checkbox-block-accordion">
@@ -104,7 +104,7 @@
     </div>
   </dd>
   <dd class="accordion-navigation">
-    <a href="#panel-1-d" class="accordion-header" draggable="false">
+    <div href="#panel-1-d" class="accordion-header" draggable="false">
       <div class="accordion-header-title">
         Accordion Selection 4 With very long name that should wrap
       </div>
@@ -114,7 +114,7 @@
         </svg>
       </span>
       {{> @icon-plus-minus active="false" }}
-    </a>
+    </div>
     <div id="panel-1-d" class="content">
       <div class="checkbox-group" role="group">
         <div class="checkbox-block-accordion">

--- a/components/02-molecules/components/accordion-plus-minus.html
+++ b/components/02-molecules/components/accordion-plus-minus.html
@@ -4,14 +4,7 @@
       <div class="accordion-header-title">
         Accordion Selection 1
       </div>
-      <span class="ui-icon ui-medium i-color">
-        <svg class="ui-minus">
-          <use xlink:href="#i-minus"></use>
-        </svg>
-        <svg class="ui-plus">
-          <use xlink:href="#i-plus"></use>
-        </svg>
-      </span>
+      {{> @icon-plus-minus active="false" }}
     </a>
     <div id="panel-1-a" class="content">
       <div class="checkbox-group" role="group">
@@ -48,14 +41,7 @@
       <div class="accordion-header-title">
         Accordion Selection 2
       </div>
-      <span class="ui-icon ui-medium i-color">
-        <svg class="ui-minus">
-          <use xlink:href="#i-minus"></use>
-        </svg>
-        <svg class="ui-plus">
-          <use xlink:href="#i-plus"></use>
-        </svg>
-      </span>
+      {{> @icon-plus-minus active="false" }}
     </a>
     <div id="panel-1-b" class="content">
       <div class="checkbox-group" role="group">
@@ -104,14 +90,7 @@
       <div class="accordion-header-title">
         Accordion Selection 3 With very long name that should wrap
       </div>
-      <span class="ui-icon ui-medium i-color">
-        <svg class="ui-minus">
-          <use xlink:href="#i-minus"></use>
-        </svg>
-        <svg class="ui-plus">
-          <use xlink:href="#i-plus"></use>
-        </svg>
-      </span>
+      {{> @icon-plus-minus active="false" }}
     </a>
     <div id="panel-1-c" class="content">
       <div class="checkbox-group" role="group">
@@ -134,14 +113,7 @@
           <use xlink:href="#i-check"></use>
         </svg>
       </span>
-      <span class="ui-icon ui-medium i-color">
-        <svg class="ui-minus">
-          <use xlink:href="#i-minus"></use>
-        </svg>
-        <svg class="ui-plus">
-          <use xlink:href="#i-plus"></use>
-        </svg>
-      </span>
+      {{> @icon-plus-minus active="false" }}
     </a>
     <div id="panel-1-d" class="content">
       <div class="checkbox-group" role="group">

--- a/components/02-molecules/components/accumulator.html
+++ b/components/02-molecules/components/accumulator.html
@@ -1,6 +1,6 @@
 <div class="accumulator-label">
   <p class="accumulator-title">You selected...</p>
-  <div class="accumulator-action">Clear All</p>
+  <span class="accumulator-action">Clear all</span>
 </div>
 <ul class="accumulator">
   <li>
@@ -30,6 +30,14 @@
   <li>
     <div class="accumulator-item-text">
       Accumulator key with long text: Even more long text (and free text too)
+    </div>
+    <span class="accumulator-x-icon">
+      {{> @icons-base icon="close" position="control"}}
+    </span>
+  </li>
+  <li>
+    <div class="accumulator-item-text">
+      Accumulator key with long text: (andaverylongfreetextstringtoseeifitbreaksthewordontomultiplelines)
     </div>
     <span class="accumulator-x-icon">
       {{> @icons-base icon="close" position="control"}}

--- a/components/02-molecules/components/accumulator.html
+++ b/components/02-molecules/components/accumulator.html
@@ -4,13 +4,33 @@
 </div>
 <ul class="accumulator">
   <li>
-    Asian: Japanese
+    <div class="accumulator-item-text">
+      Asian: Japanese
+    </div>
     <span class="accumulator-x-icon">
       {{> @icons-base icon="close" position="control"}}
     </span>
   </li>
   <li>
-    Asian: Chinese
+    <div class="accumulator-item-text">
+      Asian: Chinese
+    </div>
+    <span class="accumulator-x-icon">
+      {{> @icons-base icon="close" position="control"}}
+    </span>
+  </li>
+  <li>
+    <div class="accumulator-item-text">
+      White: Other (German)
+    </div>
+    <span class="accumulator-x-icon">
+      {{> @icons-base icon="close" position="control"}}
+    </span>
+  </li>
+  <li>
+    <div class="accumulator-item-text">
+      Accumulator key with long text: Even more long text (and free text too)
+    </div>
     <span class="accumulator-x-icon">
       {{> @icons-base icon="close" position="control"}}
     </span>

--- a/components/02-molecules/components/accumulator.html
+++ b/components/02-molecules/components/accumulator.html
@@ -1,6 +1,6 @@
 <div class="accumulator-label">
   <p class="accumulator-title">You selected...</p>
-  <p class="accumulator-action">Clear All</p>
+  <div class="accumulator-action">Clear All</p>
 </div>
 <ul class="accumulator">
   <li>

--- a/public/toolkit/styles/molecules/_accordion.scss
+++ b/public/toolkit/styles/molecules/_accordion.scss
@@ -93,8 +93,7 @@ $accordion-text-color: #4D4D4D;
 
   .ui-check {
     fill: #2E8540;
-    float: right;
-    margin-right: 2rem;
+    margin-right: 0.5rem;
   }
 
   .content {
@@ -125,9 +124,16 @@ $accordion-text-color: #4D4D4D;
     }
 
     &.accordion-header {
+      display: flex;
+      align-items: center;
       .accordion-header-title {
         // Add padding to the title so it doesn't overlap the control icons
-        padding-right: 4rem;
+        padding-right: 1rem;
+        flex-grow: 1;
+      }
+
+      :not(.accordion-header-title) {
+        flex-grow: 0;
       }
 
       margin-bottom: 0;

--- a/public/toolkit/styles/molecules/_accordion.scss
+++ b/public/toolkit/styles/molecules/_accordion.scss
@@ -125,6 +125,11 @@ $accordion-text-color: #4D4D4D;
     }
 
     &.accordion-header {
+      .accordion-header-title {
+        // Add padding to the title so it doesn't overlap the control icons
+        padding-right: 4rem;
+      }
+
       margin-bottom: 0;
       @include rounded-border();
     }

--- a/public/toolkit/styles/molecules/_accordion.scss
+++ b/public/toolkit/styles/molecules/_accordion.scss
@@ -106,13 +106,15 @@ $accordion-text-color: #4D4D4D;
     margin-bottom: 1rem !important;
   }
 
-  .accordion-navigation a, .accordion-navigation.active a {
+  .accordion-navigation div.accordion-header {
     @include type-weight(semi);
     text-decoration: none;
     color: $accordion-text-color;
     background-color: $accordion-background;
     position: relative;
     margin-bottom: 1rem;
+    padding: 1rem;
+    cursor: pointer;
 
     &:hover, &:focus {
       background-color: $accordion-background;
@@ -141,17 +143,21 @@ $accordion-text-color: #4D4D4D;
     }
   }
 
-  .accordion-navigation.active a {
-    .ui-minus {
-      @include icon-show();
+  .accordion-navigation.active {
+    .content {
+      display: block;
     }
 
-    .ui-plus {
-      @include icon-hide();
-    }
-
-    &.accordion-header {
+    div.accordion-header {
       @include rounded-bottom-border(0);
+
+      .ui-minus {
+        @include icon-show();
+      }
+
+      .ui-plus {
+        @include icon-hide();
+      }
     }
   }
 

--- a/public/toolkit/styles/molecules/_accumulator.scss
+++ b/public/toolkit/styles/molecules/_accumulator.scss
@@ -27,6 +27,13 @@ $border-width-px: 2px;
 
     .accumulator-item-text {
       padding-right: 1rem;
+
+      // need all of these options to properly break words in all browsers
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      word-break: break-all;
+      word-break: break-word;
+      hyphens: auto;
     }
 
     &:not(:first-child) {

--- a/public/toolkit/styles/molecules/_accumulator.scss
+++ b/public/toolkit/styles/molecules/_accumulator.scss
@@ -19,6 +19,10 @@ $border-width-px: 2px;
     padding-left: 1rem;
     padding-right: 1rem;
 
+    .accumulator-item-text {
+      padding-right: 1rem;
+    }
+
     &:not(:first-child) {
       margin-top: 1rem;
     }

--- a/public/toolkit/styles/molecules/_accumulator.scss
+++ b/public/toolkit/styles/molecules/_accumulator.scss
@@ -19,6 +19,12 @@ $border-width-px: 2px;
     padding-left: 1rem;
     padding-right: 1rem;
 
+    .accumulator-x-icon {
+      // Add padding and equal negative margin to increase click area.
+      padding: 0.5rem;
+      margin: -0.5rem;
+    }
+
     .accumulator-item-text {
       padding-right: 1rem;
     }


### PR DESCRIPTION
Polish the demographics styles, when adding the accordion to webapp I found some things that are not the same as the designs.

- [x] Add padding around accumulator x button
- [x] Center +/- icons
- [x] Add padding to header text so it doesn't overlap icons
![- 2020-07-16 at 5 35 47 PM](https://user-images.githubusercontent.com/64036574/87735616-e20ae300-c78a-11ea-955b-32280148850e.png)
- [x] Make sure check mark position stays in header when text is long on small screens.

### Screenshot: full size accordion
![- 2020-07-17 at 3 29 36 PM](https://user-images.githubusercontent.com/64036574/87835582-69675d80-c842-11ea-9b21-162cc4bce198.png)

### Screenshot: small accordion wraps and centers icons properly
![- 2020-07-17 at 3 29 54 PM](https://user-images.githubusercontent.com/64036574/87835618-83a13b80-c842-11ea-979a-51b024792f6a.png)

### Screenshot: accumulator with long text wraps properly
![- 2020-07-17 at 3 31 30 PM](https://user-images.githubusercontent.com/64036574/87835668-9ca9ec80-c842-11ea-8c5e-9fa560c71c1f.png)

