### PR TITLE
Remove now-unused whiteout class #173712407

### DIFF
--- a/components/01-atoms/tables/pricing-table-new--ownership.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership.html
@@ -22,9 +22,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Household Size</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Minimum</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Maximum</th>
+        <th scope="col">Household Size</th>
+        <th scope="col">Minimum</th>
+        <th scope="col">Maximum</th>
       </tr>
     </thead>
     <tbody>
@@ -38,9 +38,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Sales Price</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>HOA Dues</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Parking</th>
+        <th scope="col">Sales Price</th>
+        <th scope="col">HOA Dues</th>
+        <th scope="col">Parking</th>
       </tr>
     </thead>
     <tbody>
@@ -92,7 +92,7 @@
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}
-          <tr>{{> tableRow whiteout=@../index}}</tr>
+          <tr>{{> tableRow }}</tr>
         {{/each}}
       {{/each}}
     </tbody>

--- a/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_dual_parking.html
@@ -22,9 +22,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Household Size</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Minimum</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Maximum</th>
+        <th scope="col">Household Size</th>
+        <th scope="col">Minimum</th>
+        <th scope="col">Maximum</th>
       </tr>
     </thead>
     <tbody>
@@ -38,9 +38,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Sales Price</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>HOA Dues</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Parking</th>
+        <th scope="col">Sales Price</th>
+        <th scope="col">HOA Dues</th>
+        <th scope="col">Parking</th>
       </tr>
     </thead>
     <tbody>
@@ -76,7 +76,7 @@
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}
-          <tr>{{> tableRow whiteout=@../index}}</tr>
+          <tr>{{> tableRow }}</tr>
         {{/each}}
       {{/each}}
     </tbody>

--- a/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
+++ b/components/01-atoms/tables/pricing-table-new--ownership_with_parking.html
@@ -22,9 +22,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Household Size</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Minimum</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Maximum</th>
+        <th scope="col">Household Size</th>
+        <th scope="col">Minimum</th>
+        <th scope="col">Maximum</th>
       </tr>
     </thead>
     <tbody>
@@ -38,9 +38,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Sales Price</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>HOA Dues</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Parking</th>
+        <th scope="col">Sales Price</th>
+        <th scope="col">HOA Dues</th>
+        <th scope="col">Parking</th>
       </tr>
     </thead>
     <tbody>
@@ -71,7 +71,7 @@
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}
-          <tr>{{> tableRow whiteout=@../index}}</tr>
+          <tr>{{> tableRow }}</tr>
         {{/each}}
       {{/each}}
     </tbody>

--- a/components/01-atoms/tables/pricing-table-new.html
+++ b/components/01-atoms/tables/pricing-table-new.html
@@ -22,9 +22,9 @@
   <table class="table-nested-income">
     <thead>
       <tr>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Household Size</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Minimum</th>
-        <th scope="col"{{#if whiteout}} class="whiteout"{{/if}}>Maximum</th>
+        <th scope="col">Household Size</th>
+        <th scope="col">Minimum</th>
+        <th scope="col">Maximum</th>
       </tr>
     </thead>
     <tbody>
@@ -78,7 +78,7 @@
           <td class="income-level-label">{{this.incomeLevel}}</td>
         </tr>
         {{#each this.priceGroups}}
-          <tr>{{> tableRow whiteout=@../index}}</tr>
+          <tr>{{> tableRow }}</tr>
         {{/each}}
       {{/each}}
     </tbody>

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -616,9 +616,6 @@ table {
   th {
     text-transform: none;
     letter-spacing: 0;
-    &.whiteout {
-      color: $white;
-    }
   }
   th:last-child {
     text-align: left;


### PR DESCRIPTION
Now that we're not using the class "whiteout" to hide subheaders on DAHLIA, we can remove it from the pattern library.
Ticket: https://www.pivotaltracker.com/story/show/173712407

Review app: https://sf-dahlia-pl-remove-whiteout.herokuapp.com/

Review instructions:
Check that Patterns for [rental](https://sf-dahlia-pl-remove-whiteout.herokuapp.com/components/detail/pricing-table-new--default.html) and [sales](https://sf-dahlia-pl-remove-whiteout.herokuapp.com/components/detail/pricing-table-new--ownership_dual_parking.html) tables look as expected:
- subheaders such as "minimum" and "maximum" are no longer whited out
- "RENT" subheader is still present if you highlight the text, but is not visible